### PR TITLE
Numbat

### DIFF
--- a/.github/workflows/reusable_build_archive.yml
+++ b/.github/workflows/reusable_build_archive.yml
@@ -39,7 +39,7 @@ jobs:
           scons --Release --jobs=4 ${{ env.scons_option }}
           strip build/x64/Release/Eradication/Eradication
           ./build/x64/Release/Eradication/Eradication --get-schema --schema-path schema.json
-          grep DTK_Version schema.json | sed 's/[^0-9.]//g' | sed 's/$/.dev2/' > version
+          grep DTK_Version schema.json | sed 's/[^0-9.]//g' | sed 's/$/.dev1/' > version
       - name: Archive binary
         uses: actions/upload-artifact@v6
         with:

--- a/SConstruct
+++ b/SConstruct
@@ -218,7 +218,7 @@ else:
     env.Append( CCFLAGS=["-w"] )
     env.Append( CCFLAGS=["-ffloat-store"] )
     env.Append( CCFLAGS=["-Wno-unknown-pragmas"] )
-    #env.Append( CCFLAGS=["-mavx2"] )
+    env.Append( CCFLAGS=["-mavx2"] )
 
     # Python
     if(sys.version_info.minor == 9):


### PR DESCRIPTION
Revises GH actions to build the executable using Ubuntu 24 (python 3.12). Does not require separate Docker container.

Example output (monolithic build): https://github.com/EMOD-Hub/EMOD/actions/runs/21539918107