### PR TITLE
ReportFpgOutputForObservationalModel needs to only report the barcode alleles

### DIFF
--- a/reporters/ReportFpgOutputForObservationalModel.cpp
+++ b/reporters/ReportFpgOutputForObservationalModel.cpp
@@ -306,7 +306,7 @@ namespace Kernel
             // --- Define function that will write the nucleotide sequences to the numpy array
             // --- file such that they can be read as a 2D array.
             // --------------------------------------------------------------------------------
-            write_data_func write_func_alleles = [this, &r_barcode_indexes, &snp_data_size]( size_t num_bytes, std::ofstream& file )
+            write_data_func write_func_alleles = [this, r_barcode_indexes, snp_data_size]( size_t num_bytes, std::ofstream& file )
             { 
                 size_t bytes_written = 0;
                 if( m_GenomeList.size() > 0 )


### PR DESCRIPTION
Added code to make sure that only the "neutral"/barcode alleles are being reported on in the report. We do not want to track other ones (such as PfEMP1, MSP, HRP2, Drug Resistance) if they are present.