### PR TITLE
Fix hated, awful reporters

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -100,16 +100,8 @@ SConscript( [ 'baseReportLib/SConscript',
               'lz4/SConscript',
               'utils/SConscript' ])
 
-
 # Finally executable
 SConscript('Eradication/SConscript')
-
-
-
-
-
-
-
 
 if( disease == "ALL"):
     OptionalScript('UnitTest++/SConscript')

--- a/SConstruct
+++ b/SConstruct
@@ -368,8 +368,6 @@ elif "win32" == os.sys.platform:
 else:
     print( "No special config for [" + os.sys.platform + "] which probably means it won't work" )
 
-env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
-
 env.Append( CPPPATH=['$EXTRACPPPATH'] )
 env.Append( LIBPATH=['$EXTRALIBPATH'] )
 

--- a/reporters/SConscript_STI_RelationshipQueue
+++ b/reporters/SConscript_STI_RelationshipQueue
@@ -8,6 +8,8 @@ lib_report_dllSrcFiles = [ "$REPORT_DIR/StiRelationshipQueueReporter.cpp" ]
 if os.name != "posix":
     lib_report_dllSrcFiles.extend( [ "$REPORT_DIR/stdafx.cpp" ] )
 
+    report_env.Prepend( LIBS=["baseReportLib", "cajun", "utils" ])
+
 report_dir = report_env[ "BUILD_DIR" ] + 'reporter_plugins/' + report_env[ "REPORT_DIR" ]
 
 lib_report_Dll = report_env.SharedLibrary( report_dir, lib_report_dllSrcFiles )


### PR DESCRIPTION
~Still running tests.~

Test are good: https://github.com/EMOD-Hub/EMOD/actions/runs/25753384965

To get shared libraries on Windows: link the static libraries! The VC++ compiler is smart enough to not doubly include the statics. If those objects aren't present at runtime, it'll be a runtime error (just like it is on Linux), but the VC++ compiler will enforce that everything in the dll is defined somewhere in the project at compile-time.

To get shared libraries on linux: *do not* link the static libraries! If those objects aren't present at runtime, it'll be a runtime error, (just like it is on Windows). The risk is that the developer uses something in the shared library that's not defined in the executable. As long as the shared object is tested, this is fine.