### PR TITLE
Align Configuration methods with EMOD-Generic

### DIFF
--- a/Eradication/Controller.cpp
+++ b/Eradication/Controller.cpp
@@ -26,8 +26,6 @@ using namespace Kernel;
 SETUP_LOGGING( "Controller" )
 
 
-void StepSimulation(ISimulation* sim, float dt);
-
 // Basic simulation main loop with reporting
 void RunSimulation( ISimulation* sim, int steps, float dt )
 {
@@ -42,11 +40,12 @@ void RunSimulation( ISimulation* sim, int steps, float dt )
     {
         if (!serialization_time_steps.empty() && t == serialization_time_steps.front())
         {
-            SerializedState::SaveSerializedSimulation( dynamic_cast<Simulation*>(sim), t, true, use_full_precision );
+            SerializedState::SaveSerializedSimulation(dynamic_cast<Simulation*>(sim), t, true, use_full_precision);
             serialization_time_steps.pop_front();
         }
 
-        StepSimulation(sim, dt);
+        sim->Update(dt);
+        EnvPtr->Log->Flush();
 
         if (EnvPtr->MPI.Rank == 0)
         {
@@ -63,20 +62,12 @@ void RunSimulation( ISimulation* sim, int steps, float dt )
     bool final_in_list = std::find(serialization_time_steps.begin(), serialization_time_steps.end(), steps) != serialization_time_steps.end();
     if (!serialization_time_steps.empty() && final_in_list)
     {
-        SerializedState::SaveSerializedSimulation( dynamic_cast<Simulation*>(sim), steps, true, use_full_precision );
+        SerializedState::SaveSerializedSimulation(dynamic_cast<Simulation*>(sim), steps, true, use_full_precision);
     }
-}
-
-void StepSimulation(ISimulation* sim, float dt)
-{
-    sim->Update(dt);
-
-    EnvPtr->Log->Flush();
 }
 
 bool DefaultController::execute_internal()
 {
-
     using namespace Kernel;
     list<string> serialization_test_state_filenames;
 
@@ -87,9 +78,9 @@ bool DefaultController::execute_internal()
     SerializationParameters::GetInstance()->Configure( EnvPtr->Config );  // Has to be configured before CreateSimulation()
     JsonConfigurable::CheckMissingParameters();
 
-    std::unique_ptr<ISimulation> sim( SimulationFactory::CreateSimulation() ); 
+    std::unique_ptr<ISimulation> sim(SimulationFactory::CreateSimulation());
 
-    if (nullptr == sim.get())
+    if (!sim.get())
     {
         throw InitializationException( __FILE__, __LINE__, __FUNCTION__, "sim.get() returned NULL after call to CreateSimulation.\n" );
     }
@@ -106,7 +97,6 @@ bool DefaultController::execute_internal()
         // "Use_Defaults" in campaign.json.
         JsonConfigurable::_useDefaults = false;
         JsonConfigurable::CheckMissingParameters();
-
 
         // now try to run it
         // divide the simulation into stages according to requesting number of serialization test cycles

--- a/Eradication/Controller.h
+++ b/Eradication/Controller.h
@@ -14,21 +14,6 @@
 ** of implementation of high level simulation plans involving averaging, serialization, etc
 */
 
-template<class ControllerT>
-class ControllerExecuteFunctor
-{
-public:
-    ControllerT* controller;
-
-    ControllerExecuteFunctor(ControllerT *c) : controller(c) { }
-
-    template<class SimulationT>
-    bool call()
-    {
-        return controller->template execute_internal<SimulationT>();
-    }
-};
-
 class DefaultController : public IController
 {
 public:
@@ -36,13 +21,6 @@ public:
     virtual ~DefaultController() {}
 
 protected:
-
-    template <class SimulationT> 
     bool execute_internal();
-
-    // Non-template version
-    bool execute_internal();
-
-    friend class ControllerExecuteFunctor<DefaultController>;
 };
 

--- a/utils/Configuration.cpp
+++ b/utils/Configuration.cpp
@@ -93,7 +93,6 @@ Configuration* Configuration::LoadFromPython(
 #ifdef EMBEDDED_PYTHON_DEMO
     PyObject * pName, *pModule, *pDict, *pFunc, *pValue;
 
-    //std::cout << "Invoking python (hopefully)!" << std::endl;
     Py_Initialize();
     PyErr_Print();
     pName = PyUnicode_FromString( "emod_config" ); // need to have script emod_config.py in site-packages (or other path visible to python)
@@ -111,7 +110,6 @@ Configuration* Configuration::LoadFromPython(
     pValue = PyObject_CallObject( pFunc, vars );
     PyErr_Print();
 
-    //std::cout << PyString_AsString(pValue) << std::endl;
     std::istringstream testJsonFromPy( PyString_AsString(pValue) );
     
     Py_DECREF( pValue );
@@ -198,20 +196,6 @@ Configuration *Configuration_Load( const std::string& rFilename )
     return Configuration::Load( rFilename );
 }
 
-
-/*
-Configuration* Configuration::Load( istream &config_file )
-{    
-    return loadInternal(config_file);
-}
-
-Configuration* Configuration::loadInternalWrapper( std::istream &config_file )
-{
-    return loadInternal(config_file);
-}
-*/
-
-
 Configuration* Configuration::loadInternal( istream &is_config_file, const std::string& rDataLocation )
 {
     using namespace json;
@@ -236,43 +220,51 @@ Configuration* Configuration::CopyFromElement( const json::Element &elem, const 
     return _new_ Configuration( elem_copy, rDataLocation );
 }
 
-#if 0
-template<class Archive>
-void Configuration::serialize( Archive &ar, const unsigned int v )
-{
-    // hacked serialization....converts to string then serializes that, rather than trying to do an efficient serialization of the cajun objects themselves
-
-    if (typename Archive::is_loading())
-    {
-        string data;
-        ar & data;
-
-        istringstream iss(data, istringstream::in);
-
-        Element *elem = _new_ String();
-        Reader::Read(*elem, iss);
-
-        pElement = elem;
-#ifdef WIN32
-        this->QuickInterpreter::QuickInterpreter(*pElement); // reinit base class
-#else
-#warning "code commented out to get linux build to work"
-#endif
-
-    }
-    else
-    {
-        ostringstream oss(ostringstream::out);
-        Writer::Write(*pElement, oss);
-        // Trying 2-step for linux
-        std::string stringToSerialize = oss.str();
-        ar & stringToSerialize;
-    }
-}
-#endif
-
 /////////////////////////////////////////////////////////////////////////////////////////
 // config/json loading wrappers
+
+vector<bool> GET_CONFIG_VECTOR_BOOL(const QuickInterpreter* parameter_source, const char *name)
+{
+    vector<bool> values;
+
+    if(parameter_source == nullptr)
+    {
+        if( Kernel::JsonConfigurable::_dryrun )
+        {
+            return values;
+        }
+        else
+        {
+            throw std::runtime_error("Null pointer!  Invalid config passed for parsing");
+        }
+    }
+    try
+    {
+        json::QuickInterpreter json_array( (*parameter_source)[name].As<json::Array>() );
+        for( unsigned int idx = 0; idx < (*parameter_source)[name].As<json::Array>().Size(); idx++ )
+        {
+            int value = static_cast<int>(json_array[idx].As<json::Number>());
+            if(value != 0 && value != 1)
+            {
+                throw Kernel::JsonTypeConfigurationException( __FILE__, __LINE__, __FUNCTION__, name, (*parameter_source), "Expected only 0 or 1 in BOOL VECTOR/ARRAY" );
+            }
+            values.push_back((value==1?true:false));
+        }
+    }
+    catch( json::Exception )
+    {
+        if( Kernel::JsonConfigurable::_dryrun )
+        {
+            return values;
+        }
+        else
+        {
+            throw Kernel::JsonTypeConfigurationException( __FILE__, __LINE__, __FUNCTION__, name, (*parameter_source), "Expected BOOL VECTOR/ARRAY" );
+        }
+    }
+
+    return values;
+}
 
 vector<int> GET_CONFIG_VECTOR_INT(const QuickInterpreter* parameter_source, const char *name)
 {
@@ -794,14 +786,3 @@ double GET_CONFIG_DOUBLE(
 
     return value;
 }
-
-
-/*bool GET_CONFIG_BOOLEAN(const json::QuickInterpreter* parameter_source, const char *name)
-{
-    double d = GET_CONFIG_DOUBLE(parameter_source, name);
-
-    if(d != 0.0 && d != 1.0)
-        throw std::runtime_error(("Non-boolean value found for config parameter: " + std::string(name)).c_str());
-
-    return (d == 1.0);
-}*/

--- a/utils/Configuration.cpp
+++ b/utils/Configuration.cpp
@@ -49,6 +49,7 @@ Configuration::Configuration()
     : QuickInterpreter( json::Element() )
     , pElement( nullptr )
     , data_location("serialization")
+    , extendedConfig{}
 {
     // this ctor only for serialization, the base class will be initialized to an invalid state which deserialization must repair
 }

--- a/utils/Configuration.cpp
+++ b/utils/Configuration.cpp
@@ -3,17 +3,13 @@
 
 #include "Environment.h"
 #include "Configuration.h"
-#include "ConfigurationImpl.h"
 #include "Sugar.h"
-#include "CajunIncludes.h"
 #include "Exceptions.h"
 #include "Configure.h"
 #include "FileSystem.h"
 #ifdef EMBEDDED_PYTHON_DEMO
 #include "Python.h"
 #endif
-
-#include "Serializer.h"
 
 SETUP_LOGGING( "Configuration" )
 
@@ -713,7 +709,6 @@ set<string> GET_CONFIG_STRING_SET(const QuickInterpreter* parameter_source, cons
     return values;
 }
 
-
 string GET_CONFIG_STRING(const QuickInterpreter* parameter_source, const char *name)
 {
     string value = "";
@@ -748,7 +743,6 @@ string GET_CONFIG_STRING(const QuickInterpreter* parameter_source, const char *n
 
     return value;
 }
-
 
 double GET_CONFIG_DOUBLE(
     const QuickInterpreter* parameter_source,

--- a/utils/Configuration.h
+++ b/utils/Configuration.h
@@ -5,6 +5,7 @@
 #include <set>
 #include <vector>
 #include <map>
+#include <climits>
 
 #include "Exceptions.h"
 #include "ISupports.h"

--- a/utils/Configuration.h
+++ b/utils/Configuration.h
@@ -21,6 +21,9 @@ public:
     bool CheckElementByName(const std::string& elementName) const;
     const std::string& GetDataLocation() const { return data_location; }
 
+    bool IsObject() const { return (pElement->Type() == json::ElementType::OBJECT_ELEMENT); }
+    bool IsArray() const { return (pElement->Type() == json::ElementType::ARRAY_ELEMENT); }
+
     static Configuration* Load(std::string configFileName);
     static Configuration* Load(std::istream& rInputStream, const std::string& rDataLocation);
     static Configuration* LoadFromPython(const std::string &configFileName);
@@ -99,6 +102,12 @@ inline std::vector< float > GET_CONFIG_VECTOR_FLOAT(const json::QuickInterpreter
     return GET_CONFIG_VECTOR_FLOAT(parameter_source, name.c_str());
 }
 
+std::vector< bool > GET_CONFIG_VECTOR_BOOL(const json::QuickInterpreter* parameter_source, const char *name);
+inline std::vector< bool > GET_CONFIG_VECTOR_BOOL(const json::QuickInterpreter* parameter_source, const std::string& name)
+{
+    return GET_CONFIG_VECTOR_BOOL(parameter_source, name.c_str());
+}
+
 std::vector< int > GET_CONFIG_VECTOR_INT(const json::QuickInterpreter* parameter_source, const char *name);
 inline std::vector< int > GET_CONFIG_VECTOR_INT(const json::QuickInterpreter* parameter_source, const std::string& name)
 {
@@ -158,16 +167,10 @@ inline bool GET_CONFIG_BOOLEAN(const json::QuickInterpreter* parameter_source, c
 #define GET_CONFIG_NUMBER(_cfg, _name)    (float)GET_CONFIG_DOUBLE(_cfg, _name)
 
 
-//////////////////////////////////////////////////////////////////////////
-// Declarations for Configurable object functionality
-
 namespace Kernel
 {
     using namespace std;
     using namespace json;
-
-    //////////////////////////////////////////////////////////////////////
-    // Configuration Mechanism
 
     struct IConfigurable : ISupports
     {

--- a/utils/Configuration.h
+++ b/utils/Configuration.h
@@ -138,11 +138,7 @@ inline std::string GET_CONFIG_STRING(const json::QuickInterpreter* parameter_sou
     return GET_CONFIG_STRING(parameter_source, name.c_str());
 }
 
-#ifdef __GNUC__
-double GET_CONFIG_DOUBLE(const json::QuickInterpreter* parameter_source, const char *name, int min = -1*std::numeric_limits<int>::max());
-#else
 double GET_CONFIG_DOUBLE(const json::QuickInterpreter* parameter_source, const char *name, int min = -1*INT_MAX);
-#endif
 inline double GET_CONFIG_DOUBLE(const json::QuickInterpreter* parameter_source, const std::string& name)
 {
     return GET_CONFIG_DOUBLE(parameter_source, name.c_str());

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -890,6 +890,29 @@ namespace Kernel
     void
     JsonConfigurable::initConfigTypeMap(
         const char* paramName,
+        std::vector< bool > * pVariable,
+        const char* description,
+        const char* condition_key, const char* condition_value
+    )
+    {
+        LOG_DEBUG_F( "initConfigTypeMap<vector<bool>>: %s\n", paramName);
+        GetConfigData()->vectorBoolConfigTypeMap[ paramName ] = pVariable;
+        json::Object newParamSchema;
+        if ( _dryrun )
+        {
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector Bool");
+            newParamSchema["default"] = json::Array();
+        }
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
+    }
+
+    void
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
         std::vector< int > * pVariable,
         const char* description,
         int min, int max, bool ascending,
@@ -1771,6 +1794,54 @@ namespace Kernel
             LOG_DEBUG_F( "the key %s = uint32_t %u\n", key.c_str(), *(entry.second) );
         }
 
+        // ---------------------------------- uint64_t -------------------------------------
+        for( auto& entry : GetConfigData()->uint64ConfigTypeMap )
+        {
+            const std::string& key = entry.first;
+            json::QuickInterpreter schema = jsonSchemaBase[ key ];
+            uint64_t val = 0;
+
+            if( ignoreParameter( schema, inputJson ) )
+            {
+                continue; // param is missing and that's ok." << std::endl;
+            }
+
+            // check if parameter was specified in input json (TODO: improve performance by getting the iterator here with Find() and reusing instead of GET_CONFIG_INTEGER below)
+            if( inputJson->Exist( key ) )
+            {
+                // get specified configuration parameter
+                double jsonValueAsDouble = GET_CONFIG_DOUBLE( inputJson, key.c_str() );
+                if( jsonValueAsDouble != (uint64_t)jsonValueAsDouble )
+                {
+                    std::ostringstream errMsg; // using a non-parameterized exception.
+                    errMsg << "The value for parameter '"<< key << "' appears to be a decimal ("
+                           << jsonValueAsDouble
+                           << ") but needs to be an integer." << std::endl;
+                    throw Kernel::GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, errMsg.str().c_str() );
+                }
+                val = uint64_t( jsonValueAsDouble );
+                // throw exception if value is outside of range
+                EnforceParameterRange<uint64_t>( key, val, schema );
+                *(entry.second) = val;
+            }
+            else
+            {
+                if( _useDefaults )
+                {
+                    // using the default value
+                    val = (uint64_t)schema[ "default" ].As<json::Number>();
+                    LOG_DEBUG_F( "Using the default value ( \"%s\" : %d ) for unspecified parameter.\n", key.c_str(), val );
+                    *(entry.second) = val;
+                }
+                else // not in config, not using defaults, no depends-on, just plain missing
+                {
+                    handleMissingParam( key, inputJson->GetDataLocation() );
+                }
+            }
+
+            LOG_DEBUG_F( "the key %s = uint64_t %u\n", key.c_str(), *(entry.second) );
+        }
+
         // ---------------------------------- FLOAT ------------------------------------
         for (auto& entry : GetConfigData()->floatConfigTypeMap)
         {
@@ -2145,8 +2216,28 @@ namespace Kernel
             {
                 std::vector<float> configValues = GET_CONFIG_VECTOR_FLOAT( inputJson, (entry.first).c_str() );
                 *(entry.second) = configValues;
-
                 EnforceVectorParameterRanges<float>(key, configValues, schema);
+            }
+            else if( !_useDefaults )
+            {
+                handleMissingParam( key, inputJson->GetDataLocation() );
+            }
+        }
+
+        //----------------------------------- VECTOR of BOOLs ------------------------------
+        for (auto& entry : GetConfigData()->vectorBoolConfigTypeMap)
+        {
+            const std::string& key = entry.first;
+            json::QuickInterpreter schema = jsonSchemaBase[key];
+            if( ignoreParameter( schema, inputJson ) )
+            {
+                continue; // param is missing and that's ok.
+            }
+
+            if( inputJson->Exist(key) )
+            {
+                std::vector<bool> configValues = GET_CONFIG_VECTOR_BOOL( inputJson, (entry.first).c_str() );
+                *(entry.second) = configValues;
             }
             else if( !_useDefaults )
             {

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -224,7 +224,7 @@ namespace Kernel
     {
         if( !inputJson->Exist( key ) )
         {
-            throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, inputJson->GetDataLocation().c_str(), key.c_str() );
+            throw MissingParameterFromConfigurationException(__FILE__, __LINE__, __FUNCTION__, inputJson->GetDataLocation().c_str(), key.c_str());
         }
         _json = (*inputJson)[key];
     }
@@ -290,7 +290,6 @@ namespace Kernel
         return schema;
     }
     /// END OF InterventionConfig
-
 
     /// WaningConfig
     WaningConfig::WaningConfig()
@@ -1365,7 +1364,22 @@ namespace Kernel
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
 
         jsonSchemaBase[ paramName ] = newParamSchema;
+    }
 
+    void
+    JsonConfigurable::handleMissingParam( const std::string& key, const std::string& rDataLocation )
+    {
+        LOG_DEBUG_F( "%s: key = %s, _track_missing = %d.\n", __FUNCTION__, key.c_str(), _track_missing );
+        if( _track_missing )
+        {
+            missing_parameters_set.insert(key);
+        }
+        else
+        {
+            std::stringstream ss;
+            ss << key << " of " << GetTypeName();
+            throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, rDataLocation.c_str(), ss.str().c_str() );
+        }
     }
 
     void
@@ -1508,13 +1522,12 @@ namespace Kernel
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            EventTrigger * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        EventTrigger * pVariable,
+        const char * description,
+        const char* condition_key, const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTrigger>: %s\n", paramName );
         json::Object newParamSchema;
@@ -1546,8 +1559,7 @@ namespace Kernel
         const char* paramName,
         std::vector<EventTrigger>* pVariable,
         const char* description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName);
@@ -1580,8 +1592,7 @@ namespace Kernel
         const char* paramName,
         EventTriggerNode * pVariable,
         const char * description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerNode>: %s\n", paramName );
@@ -1614,8 +1625,7 @@ namespace Kernel
         const char* paramName,
         std::vector<EventTriggerNode> * pVariable,
         const char * description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName );
@@ -1648,8 +1658,7 @@ namespace Kernel
         const char* paramName,
         EventTriggerCoordinator * pVariable,
         const char * description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerCoordinator>: %s\n", paramName );
@@ -1682,8 +1691,7 @@ namespace Kernel
         const char* paramName,
         std::vector<EventTriggerCoordinator> * pVariable,
         const char * description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTriggerCoordinator>>: %s\n", paramName );
@@ -1709,22 +1717,6 @@ namespace Kernel
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
 
         jsonSchemaBase[ paramName ] = newParamSchema;
-    }
-
-    void
-    JsonConfigurable::handleMissingParam( const std::string& key, const std::string& rDataLocation )
-    {
-        LOG_DEBUG_F( "%s: key = %s, _track_missing = %d.\n", __FUNCTION__, key.c_str(), _track_missing );
-        if( _track_missing )
-        {
-            missing_parameters_set.insert(key);
-        }
-        else
-        {
-            std::stringstream ss;
-            ss << key << " of " << GetTypeName();
-            throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, rDataLocation.c_str(), ss.str().c_str() );
-        }
     }
 
     void JsonConfigurable::CheckMissingParameters()
@@ -1961,6 +1953,7 @@ namespace Kernel
                 {
                     // using the default value
                     val = (float)schema["default"].As<json::Number>();
+                    EnforceParameterRange<float>( key, val, schema );
                     LOG_DEBUG_F( "Using the default value ( \"%s\" : %f ) for unspecified parameter.\n", key.c_str(), val );
                     *(entry.second) = val;
                 }
@@ -2038,6 +2031,7 @@ namespace Kernel
                 {
                     // using the default value
                     val = (float)schema["default"].As<json::Number>();
+                    EnforceParameterRange<float>( key, val, schema );
                     LOG_DEBUG_F( "Using the default value ( \"%s\" : %f ) for unspecified parameter.\n", key.c_str(), val );
                     *(entry.second) = val;
                 }

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -533,6 +533,35 @@ namespace Kernel
     void
     JsonConfigurable::initConfigTypeMap(
         const char* paramName,
+        uint64_t * pVariable,
+        const char * description,
+        uint64_t min, uint64_t max, uint64_t defaultvalue,
+        const char* condition_key, const char* condition_value
+    )
+    {
+        LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName );
+        json::Object newParamSchema;
+        newParamSchema[ "min" ] = json::Number( min );
+        newParamSchema[ "max" ] = json::Number( max );
+        newParamSchema[ "default" ] = json::Number( defaultvalue );
+        if( _dryrun )
+        {
+            newParamSchema[ "description" ] = json::String( description );
+            newParamSchema[ "type" ] = json::String( "integer" );
+        }
+        else
+        {
+            GetConfigData()->uint64ConfigTypeMap[ paramName ] = pVariable;
+        }
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[ paramName ] = newParamSchema;
+    }
+
+    void
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
         float * pVariable,
         const char * description,
         float min, float max, float defaultvalue,

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -20,7 +20,11 @@ SETUP_LOGGING( "JsonConfigurable" )
 
 namespace Kernel
 {
-    // two functions. second is wrapper around this. Can consolidate into single.
+    // Two ignoreParameter functions; second one is a wrapper around the first.
+    // Second function calls the first function twice, first time using a variable pJson configuration, and then a second
+    // time using the simulation configuration stored in the EnvPtr. This pattern allows some cross-file dependencies.
+    // Example: a campaign parameter can be contingent on a config parameter. Note that the config in the EnvPtr may
+    // be null; if the config in the EnvPtr is null (e.g., in a DLL), then an ignorable parameter may still be required.
     bool ignoreParameter( const json::QuickInterpreter * pJson, const char * condition_key, const char * condition_value )
     {
         if( condition_key != nullptr ) 
@@ -32,9 +36,8 @@ namespace Kernel
 
                 if( condition_value == nullptr )
                 {
-                    // condition_value is null, so it's a bool and 1 (no other options)
-                    auto c_value2 = (int) c_value.As<json::Number>();
-                    if( c_value2 != 1 )
+                    // condition_value is null, so condition_key is a bool and condition_value is true
+                    if( static_cast<int>(c_value.As<json::Number>()) == 0 )
                     {
                         // Condition for using this param is false (mismatch), so returning
                         LOG_DEBUG_F( "bool condition_value found but is false/0. That makes this check fail.\n" );
@@ -42,14 +45,29 @@ namespace Kernel
                     }
                     else
                     {
-                        LOG_DEBUG_F( "bool condition_value found and is true/1. That makes this check pass.\n" );
                         // Conditions match. Continue and return false at end.
+                        LOG_DEBUG_F( "bool condition_value found and is true/1. That makes this check pass.\n" );
+                    }
+                }
+                else if( (std::string(condition_key)).rfind("Enable_", 0) == 0 )
+                {
+                    // condition_key starts with "Enable_", so condition_key is a bool
+                    if( static_cast<int>(c_value.As<json::Number>()) != std::stoi(std::string(condition_value),nullptr) )
+                    {
+                        // Condition for using this param is false (mismatch), so returning
+                        LOG_DEBUG_F( "bool condition_value found but does not match specified value. That makes this check fail.\n" );
+                        return true;
+                    }
+                    else
+                    {
+                        // Conditions match. Continue and return false at end.
+                        LOG_DEBUG_F( "bool condition_value found and matches specified value. That makes this check pass.\n" );
                     }
                 }
                 else
                 {
                     // condition_value is not null, so it's a string (enum); let's read it.
-                    auto c_value_from_config = (std::string) c_value.As<json::String>();
+                    auto c_value_from_config = GET_CONFIG_STRING(pJson, condition_key);
                     LOG_DEBUG_F( "string/enum condition_value (from config.json) = %s. Will check if matches schema condition_value (raw) = %s\n", c_value_from_config.c_str(), condition_value );
                     // see if schema condition value is multiples...
                     auto c_values = IdmString( condition_value ).split( ',' );
@@ -88,26 +106,44 @@ namespace Kernel
     {
         if( schema.Exist( "depends-on" ) )
         {
-            auto condition = json_cast<const json::Object&>(schema["depends-on"]);
-            std::string condition_key = condition.Begin()->name;
-            std::string condition_value_str = "";
-            const char * condition_value = nullptr;
-            try {
-                condition_value_str = (std::string) (json::QuickInterpreter( condition )[ condition_key ]).As<json::String>();
-                condition_value = condition_value_str.c_str();
-                LOG_DEBUG_F( "schema condition value appears to be string/enum: %s.\n", condition_value );
-            }
-            catch(...)
+            auto condition_list = json_cast<const json::Object&>(schema["depends-on"]);
+            for(auto itr1 = condition_list.Begin(); itr1 != condition_list.End(); itr1++)
             {
-                //condition_value = std::to_string( (int) (json::QuickInterpreter( condition )[ condition_key ]).As<json::Number>() );
-                LOG_DEBUG_F( "schema condition value appears to be bool, not string.\n" );
-            }
+                std::string condition_key = itr1->name;
+                std::string condition_value_str = "";
+                std::string condition_value_int = "";
+                const char* condition_value = nullptr;
 
-            if( ignoreParameter( pJson, condition_key.c_str(), condition_value ) )
-            { 
-                if( ignoreParameter( EnvPtr->Config, condition_key.c_str(), condition_value ) )
+                try
                 {
-                    return true;
+                    condition_value_str = (json::QuickInterpreter(itr1->element)).As<json::String>();
+                    condition_value = condition_value_str.c_str();
+                    LOG_DEBUG_F( "schema condition value appears to be string/enum: %s.\n", condition_value );
+                }
+                catch(...)
+                {
+                    LOG_DEBUG_F( "schema condition value appears to be bool, not string.\n" );
+                    // A bool conditions starting with Enable_ could be null or integer; 
+                    if( (std::string(condition_key)).rfind("Enable_", 0) == 0 )
+                    {
+                        try
+                        {
+                            condition_value_int = std::to_string(static_cast<int>((json::QuickInterpreter(itr1->element)).As<json::Number>()));
+                            condition_value     = condition_value_int.c_str();
+                        }
+                        catch(...)
+                        {
+                            // Pass
+                        }
+                    }
+                }
+
+                if( ignoreParameter( pJson, condition_key.c_str(), condition_value ) )
+                { 
+                    if( ignoreParameter( EnvPtr->Config, condition_key.c_str(), condition_value ) )
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -226,6 +226,10 @@ namespace Kernel
         : InterventionConfig()
     { }
 
+    IndividualInterventionConfig::IndividualInterventionConfig(json::QuickInterpreter* qi)
+        : InterventionConfig(qi)
+    { }
+
     json::QuickBuilder IndividualInterventionConfig::GetSchema()
     {
         json::QuickBuilder schema = InterventionConfig::GetSchema();
@@ -235,14 +239,22 @@ namespace Kernel
         return schema;
     }
 
+    NodeInterventionConfig::NodeInterventionConfig()
+        : InterventionConfig()
+    { }
+
+    NodeInterventionConfig::NodeInterventionConfig(json::QuickInterpreter* qi)
+        : InterventionConfig(qi)
+    { }
+
     json::QuickBuilder NodeInterventionConfig::GetSchema()
     {
         json::QuickBuilder schema = InterventionConfig::GetSchema();
         auto tn = JsonConfigurable::_typename_label();
-        schema[ tn ] = json::String( "idmAbstractType:NodeIntervention" );
+        schema[tn] = json::String( "idmAbstractType:NodeIntervention" );
+
         return schema;
     }
-
     /// END OF InterventionConfig
 
 

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -26,11 +26,10 @@ namespace Kernel
     {
         if( condition_key != nullptr ) 
         {
-            if( pJson &&
-                pJson->Exist(condition_key) == true )
+            if( pJson && pJson->Exist(condition_key) == true )
             {
+                // condition_key is in config. Read value
                 auto c_value = (*pJson)[condition_key];
-                // condition_key is in config. Read value 
 
                 if( condition_value == nullptr )
                 {
@@ -126,7 +125,7 @@ namespace Kernel
     {}
 
     NodeSetConfig::NodeSetConfig(json::QuickInterpreter* qi)
-    : _json(*qi)
+        : _json(*qi)
     {
     }
 
@@ -135,14 +134,11 @@ namespace Kernel
         json::QuickBuilder schema( jsonSchemaBase );
         auto tn = JsonConfigurable::_typename_label();
         schema[ tn ] = json::String( "idmAbstractType:NodeSet" );
+
         return schema;
     }
 
-    void
-    NodeSetConfig::ConfigureFromJsonAndKey(
-        const Configuration* inputJson,
-        const std::string& key
-    )
+    void NodeSetConfig::ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key )
     {
         if( !inputJson->Exist( key ) )
         {
@@ -150,8 +146,6 @@ namespace Kernel
         }
 
         _json = (*inputJson)[key];
-        //std::cout << "NodeSetConfig::Configure called with json blob." << std::endl;
-        //json::Writer::Write( _json, std::cout );
     }
 
     /// END NodeSetConfig
@@ -165,19 +159,13 @@ namespace Kernel
     {
     }
 
-    void
-    EventConfig::ConfigureFromJsonAndKey(
-        const Configuration* inputJson,
-        const std::string& key
-    )
+    void EventConfig::ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key )
     {
         if( !inputJson->Exist( key ) )
         {
             throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, inputJson->GetDataLocation().c_str(), key.c_str() );
         }
         _json = (*inputJson)[key];
-        //std::cout << "EventConfig::Configure called with json blob." << std::endl;
-        //json::Writer::Write( _json, std::cout );
     }
 
     json::QuickBuilder EventConfig::GetSchema()
@@ -185,47 +173,34 @@ namespace Kernel
         json::QuickBuilder schema( jsonSchemaBase );
         auto tn = JsonConfigurable::_typename_label();
         schema[ tn ] = json::String( "idmAbstractType:EventCoordinator" );
+
         return schema;
     }
 
     /// InterventionConfig
     InterventionConfig::InterventionConfig()
-    //: _qi( _json )
-    {}
+        : _json()
+    { }
 
     InterventionConfig::InterventionConfig(json::QuickInterpreter* qi)
         : _json(*qi)
-        //, _qi(*qi)
-    {
-        //json::Writer::Write( _json, std::cout );
-        //std::cout << "Yay, we can write out our _json!" << std::endl;
-    }
+    { }
 
-    void
-    InterventionConfig::ConfigureFromJsonAndKey(
-        const Configuration* inputJson,
-        const std::string& key
-    )
+    void InterventionConfig::ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key )
     {
         if( !inputJson->Exist( key ) )
         {
             throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, inputJson->GetDataLocation().c_str(), key.c_str() );
         }
-        // we need to set _json to inputJson
         _json = (*inputJson)[key];
-
-        // This might be useful for debugging, but couldn't agree on how to whether to include or not. Uncomment if you need it.
-        /*std::ostringstream msg;
-        msg << "InterventionConfig::" << __FUNCTION__ << " called with json blob." << std::endl;
-        json::Writer::Write( _json, msg );
-        LOG_DEBUG_F( "%s", msg.str().c_str() );*/
     }
 
     json::QuickBuilder InterventionConfig::GetSchema()
     {
         json::QuickBuilder schema( jsonSchemaBase );
         auto tn = JsonConfigurable::_typename_label();
-        schema[ tn ] = json::String( "idmAbstractType:Intervention" );
+        schema[tn] = json::String( "idmAbstractType:Intervention" );
+
         return schema;
     }
 
@@ -248,14 +223,15 @@ namespace Kernel
     }
 
     IndividualInterventionConfig::IndividualInterventionConfig()
-    {
-    }
+        : InterventionConfig()
+    { }
 
     json::QuickBuilder IndividualInterventionConfig::GetSchema()
     {
         json::QuickBuilder schema = InterventionConfig::GetSchema();
         auto tn = JsonConfigurable::_typename_label();
-        schema[ tn ] = json::String( "idmAbstractType:IndividualIntervention" );
+        schema[tn] = json::String( "idmAbstractType:IndividualIntervention" );
+
         return schema;
     }
 
@@ -272,12 +248,11 @@ namespace Kernel
 
     /// WaningConfig
     WaningConfig::WaningConfig()
-    {}
+    { }
 
     WaningConfig::WaningConfig(json::QuickInterpreter* qi)
-    : _json(*qi)
-    {
-    }
+        : _json(*qi)
+    { }
 
     json::QuickBuilder WaningConfig::GetSchema()
     {
@@ -287,31 +262,23 @@ namespace Kernel
         return schema;
     }
 
-    void
-    WaningConfig::ConfigureFromJsonAndKey(
-        const Configuration* inputJson,
-        const std::string& key
-    )
+    void WaningConfig::ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key )
     {
         if( !inputJson->Exist( key ) )
         {
             throw MissingParameterFromConfigurationException( __FILE__, __LINE__, __FUNCTION__, inputJson->GetDataLocation().c_str(), key.c_str() );
         }
         _json = (*inputJson)[key];
-        //std::cout << "WaningConfig::Configure called with json blob." << std::endl;
-        //json::Writer::Write( _json, std::cout );
     }
-
     /// END WaningConfig
 
     /// AdditionalTargetingConfig
     AdditionalTargetingConfig::AdditionalTargetingConfig()
-    {}
+    { }
 
     AdditionalTargetingConfig::AdditionalTargetingConfig(json::QuickInterpreter* qi)
         : _json(*qi)
-    {
-    }
+    { }
 
     json::QuickBuilder AdditionalTargetingConfig::GetSchema()
     {
@@ -321,11 +288,7 @@ namespace Kernel
         return schema;
     }
 
-    void
-        AdditionalTargetingConfig::ConfigureFromJsonAndKey(
-            const Configuration* inputJson,
-            const std::string& key
-        )
+    void AdditionalTargetingConfig::ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key )
     {
         if (!inputJson->Exist(key))
         {
@@ -333,30 +296,28 @@ namespace Kernel
         }
         _json = (*inputJson)[key];
     }
-
     /// END AdditionalTargetingConfig
 
     namespace jsonConfigurable
     {
         ConstrainedString::ConstrainedString()
-        :constraint_param(nullptr)
+            : constraint_param(nullptr)
         {
         }
 
         ConstrainedString::ConstrainedString( const std::string &init_str )
-        : constraint_param(nullptr)
+            : constraint_param(nullptr)
         {
             *((std::string*)(this)) = init_str;
         }
 
         ConstrainedString::ConstrainedString( const char* init_str )
-        : constraint_param(nullptr)
+            : constraint_param(nullptr)
         {
             *((std::string*)(this)) = std::string( init_str );
         }
 
-        const ConstrainedString&
-        ConstrainedString::operator=( const std::string& new_value )
+        const ConstrainedString& ConstrainedString::operator=( const std::string& new_value )
         {
             *((std::string*)(this)) = new_value;
             if( constraint_param &&
@@ -411,9 +372,9 @@ namespace Kernel
     }
 
     JsonConfigurable::JsonConfigurable()
-    : IConfigurable()
-    , m_pData( nullptr )
-    , jsonSchemaBase()
+        : IConfigurable()
+        , m_pData( nullptr )
+        , jsonSchemaBase()
     {
         // -----------------------------------------------------------------------
         // --- We don't want to create the ConfigData in the constructor because
@@ -423,9 +384,9 @@ namespace Kernel
     }
 
     JsonConfigurable::JsonConfigurable( const JsonConfigurable& rConfig )
-    : IConfigurable()
-    , m_pData( nullptr ) // !!! Don't copy stuff
-    , jsonSchemaBase( rConfig.jsonSchemaBase )
+        : IConfigurable()
+        , m_pData( nullptr ) // !!! Don't copy stuff
+        , jsonSchemaBase( rConfig.jsonSchemaBase )
     {
         if( rConfig.m_pData != nullptr )
         {
@@ -493,21 +454,21 @@ namespace Kernel
     {
         LOG_DEBUG_F("initConfigTypeMap<bool>: %s\n", paramName);
 
-        json::Object newIntSchema;
-        // Use this when boolean configuration parameters are actually 'true'/'false'.
-        //newIntSchema["default"] = json::Boolean(defaultvalue); 
-        newIntSchema["default"] = json::Number(defaultvalue ? 1 : 0);
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::Number(defaultvalue ? 1 : 0);
         if ( _dryrun )
         {
-            newIntSchema["description"] = json::String(description);
-            newIntSchema["type"] = json::String( "bool" );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "bool" );
         }
         else
         {
             GetConfigData()->boolConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newIntSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newIntSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -521,49 +482,52 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName);
 
-        json::Object newIntSchema;
-        newIntSchema["min"] = json::Number(min);
-        newIntSchema["max"] = json::Number(max);
-        newIntSchema["default"] = json::Number(defaultvalue);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
+        newParamSchema["default"] = json::Number(defaultvalue);
         if ( _dryrun )
         {
-            newIntSchema["description"] = json::String(description);
-            newIntSchema["type"] = json::String( "integer" );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "integer" );
         }
         else
         {
             GetConfigData()->intConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newIntSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newIntSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            uint32_t * pVariable,
-            const char * description,
-            uint32_t min, uint32_t max, uint32_t defaultvalue,
-            const char* condition_key, const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        uint32_t * pVariable,
+        const char * description,
+        uint32_t min, uint32_t max, uint32_t defaultvalue,
+        const char* condition_key, const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName );
-
-        json::Object newUint32Schema;
-        newUint32Schema[ "min" ] = json::Number( min );
-        newUint32Schema[ "max" ] = json::Number( max );
-        newUint32Schema[ "default" ] = json::Number( defaultvalue );
+        json::Object newParamSchema;
+        newParamSchema[ "min" ] = json::Number( min );
+        newParamSchema[ "max" ] = json::Number( max );
+        newParamSchema[ "default" ] = json::Number( defaultvalue );
         if( _dryrun )
         {
-            newUint32Schema[ "description" ] = json::String( description );
-            newUint32Schema[ "type" ] = json::String( "integer" );
+            newParamSchema[ "description" ] = json::String( description );
+            newParamSchema[ "type" ] = json::String( "integer" );
         }
         else
         {
             GetConfigData()->uint32ConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newUint32Schema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newUint32Schema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
@@ -576,22 +540,23 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<float>: %s\n", paramName);
-
-        json::Object newFloatSchema;
-        newFloatSchema["min"] = json::Number(min);
-        newFloatSchema["max"] = json::Number(max);
-        newFloatSchema["default"] = json::Number(defaultvalue);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
+        newParamSchema["default"] = json::Number(defaultvalue);
         if ( _dryrun )
         {
-            newFloatSchema["description"] = json::String(description);
-            newFloatSchema["type"] = json::String( "float" ); 
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "float" ); 
         }
         else
         {
             GetConfigData()->floatConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newFloatSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newFloatSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -605,21 +570,23 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<double>: %s\n", paramName);
 
-        json::Object newDoubleSchema;
-        newDoubleSchema["min"] = json::Number(min);
-        newDoubleSchema["max"] = json::Number(max);
-        newDoubleSchema["default"] = json::Number(defaultvalue);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
+        newParamSchema["default"] = json::Number(defaultvalue);
         if ( _dryrun )
         {
-            newDoubleSchema["description"] = json::String(description);
-            newDoubleSchema["type"] = json::String("double");
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("double");
         }
         else
         {
             GetConfigData()->doubleConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newDoubleSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newDoubleSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -632,20 +599,21 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<string>: %s\n", paramName);
-
-        json::Object newStringSchema;
-        newStringSchema["default"] = json::String(default_str);
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String(default_str);
         if ( _dryrun )
         {
-            newStringSchema["description"] = json::String(description);
-            newStringSchema["type"] = json::String("string");
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("string");
         }
         else
         {
             GetConfigData()->stringConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newStringSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newStringSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -658,21 +626,22 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<ConstrainedString>: %s\n", paramName);
-
-        json::Object newConStringSchema;
-        newConStringSchema["default"] = json::String(default_str); // would be nice if this always in the constraint list!
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String(default_str); // would be nice if this always in the constraint list!
         if ( _dryrun )
         {
-            newConStringSchema["description"] = json::String(description);
-            newConStringSchema["type"] = json::String("Constrained String");
-            newConStringSchema["value_source"] = json::String( pVariable->constraints );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Constrained String");
+            newParamSchema["value_source"] = json::String( pVariable->constraints );
         }
         else
         {
             GetConfigData()->conStringConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newConStringSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newConStringSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
 
@@ -681,32 +650,29 @@ namespace Kernel
         const char* paramName,
         jsonConfigurable::tStringSetBase * pVariable,
         const char* description,
-        const char* condition_key,
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<set<string>>: %s\n", paramName);
-
-        json::Object root;
-        json::QuickBuilder newStringSetSchema( root );
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newStringSetSchema["description"] = json::String(description);
-            newStringSetSchema["type"] = json::String( pVariable->getTypeName() );
-            newStringSetSchema["default"] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( pVariable->getTypeName() );
+            newParamSchema["default"] = json::Array();
 
             if( pVariable->getTypeName() == FIXED_STRING_SET_LABEL )
             {
-                unsigned int counter = 0;
-                newStringSetSchema["possible_values"] = json::Array();
+                json::Array pval_array;
                 for( auto& value : ((jsonConfigurable::tFixedStringSet*)pVariable)->possible_values )
                 {
-                    newStringSetSchema["possible_values"][counter++] = json::String( value );
+                    pval_array.Insert(json::String(value), pval_array.End());
                 }
+                newParamSchema["possible_values"] = pval_array;
             }
             else if( pVariable->getTypeName() == DYNAMIC_STRING_SET_LABEL )
             {
-                newStringSetSchema["value_source"] = json::String( ((jsonConfigurable::tDynamicStringSet*)pVariable)->value_source );
+                newParamSchema["value_source"] = json::String( ((jsonConfigurable::tDynamicStringSet*)pVariable)->value_source );
             }
             else
             {
@@ -717,8 +683,10 @@ namespace Kernel
         {
             GetConfigData()->stringSetConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( root, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newStringSetSchema.As<json::Object>();
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -732,17 +700,16 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<string>>: %s\n", paramName);
-
-        json::Object newVectorStringSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newVectorStringSchema["description"] = json::String(description);
-            newVectorStringSchema["type"] = json::String("Vector String");
-            newVectorStringSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector String");
+            newParamSchema[ "default" ] = json::Array();
 
             if( constraint_schema )
             {
-                newVectorStringSchema["value_source"] = json::String( constraint_schema );
+                newParamSchema["value_source"] = json::String( constraint_schema );
             }
         }
         else
@@ -750,8 +717,10 @@ namespace Kernel
             GetConfigData()->vectorStringConfigTypeMap[ paramName ] = pVariable;
             GetConfigData()->vectorStringConstraintsTypeMap[ paramName ] = &constraint_variable;
         }
-        updateSchemaWithCondition( newVectorStringSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVectorStringSchema;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -765,16 +734,15 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<string>>>: %s\n", paramName);
-
-        json::Object newVectorStringSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newVectorStringSchema["description"] = json::String(description);
-            newVectorStringSchema["type"] = json::String("Vector2d String");
-            newVectorStringSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector2d String");
+            newParamSchema[ "default" ] = json::Array();
             if( constraint_schema )
             {
-                newVectorStringSchema["value_source"] = json::String( constraint_schema );
+                newParamSchema["value_source"] = json::String( constraint_schema );
             }
         }
         else
@@ -782,8 +750,10 @@ namespace Kernel
             GetConfigData()->vector2dStringConfigTypeMap[ paramName ] = pVariable;
             GetConfigData()->vector2dStringConstraintsTypeMap[ paramName ] = &constraint_variable;
         }
-        updateSchemaWithCondition( newVectorStringSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVectorStringSchema;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void JsonConfigurable::initConfigTypeMap(
@@ -797,15 +767,15 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<vector<string>>>>: %s\n", paramName);
 
-        json::Object newVectorStringSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newVectorStringSchema["description"] = json::String(description);
-            newVectorStringSchema["type"] = json::String("Vector3d String");
-            newVectorStringSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector3d String");
+            newParamSchema[ "default" ] = json::Array();
             if( constraint_schema )
             {
-                newVectorStringSchema["value_source"] = json::String( constraint_schema );
+                newParamSchema["value_source"] = json::String( constraint_schema );
             }
         }
         else
@@ -813,65 +783,67 @@ namespace Kernel
             GetConfigData()->vector3dStringConfigTypeMap[ paramName ] = pVariable;
             GetConfigData()->vector3dStringConstraintsTypeMap[ paramName ] = &constraint_variable;
         }
-        updateSchemaWithCondition( newVectorStringSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVectorStringSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector< std::vector< std::vector<float> > > * pVariable,
-            const char* description,
-            float min, float max,
-            const char* condition_key, const char* condition_value
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector< std::vector< std::vector<float> > > * pVariable,
+        const char* description,
+        float min, float max,
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<vector<float>>>: %s\n", paramName );
-
-        json::Object newVector3dFloatSchema;
-        newVector3dFloatSchema["min"] = json::Number(min);
-        newVector3dFloatSchema["max"] = json::Number(max);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
         if ( _dryrun )
         {
-            newVector3dFloatSchema["description"] = json::String(description);
-            newVector3dFloatSchema["type"] = json::String("Vector3d Float");
-            newVector3dFloatSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector3d Float");
+            newParamSchema[ "default" ] = json::Array();
         }
         else
         {
             GetConfigData()->vector3dFloatConfigTypeMap[paramName] = pVariable;
         }
-        updateSchemaWithCondition( newVector3dFloatSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVector3dFloatSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector< float > * pVariable,
-            const char* description,
-            float min, float max,  bool ascending,
-            const char* condition_key, const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector< float > * pVariable,
+        const char* description,
+        float min, float max, bool ascending,
+        const char* condition_key, const char* condition_value
+    )
     {
         LOG_DEBUG_F("initConfigTypeMap<vector<float>>: %s\n", paramName);
-
-        json::Object newVectorFloatSchema;
-        newVectorFloatSchema["min"] = json::Number(min);
-        newVectorFloatSchema["max"] = json::Number(max);
-        newVectorFloatSchema["ascending"] = json::Number(ascending ? 1 : 0);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
+        newParamSchema["ascending"] = json::Number(ascending ? 1 : 0);
         if (_dryrun)
         {
-            newVectorFloatSchema["description"] = json::String(description);
-            newVectorFloatSchema["type"] = json::String("Vector Float");
-            newVectorFloatSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector Float");
+            newParamSchema["default"] = json::Array();
         }
         else
         {
             GetConfigData()->vectorFloatConfigTypeMap[paramName] = pVariable;
         }
-        updateSchemaWithCondition(newVectorFloatSchema, condition_key, condition_value);
-        jsonSchemaBase[paramName] = newVectorFloatSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -884,52 +856,54 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<int>>: %s\n", paramName);
-
-        json::Object newVectorIntSchema;
-        newVectorIntSchema["min"] = json::Number(min);
-        newVectorIntSchema["max"] = json::Number(max);
-        newVectorIntSchema["ascending"] = json::Number( ascending ? 1 : 0 );
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
+        newParamSchema["ascending"] = json::Number(ascending ? 1 : 0);
         if ( _dryrun )
         {
-            newVectorIntSchema["description"] = json::String(description);
-            newVectorIntSchema["type"] = json::String("Vector Int");
-            newVectorIntSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector Int");
+            newParamSchema["default"] = json::Array();
         }
         else
         {
             GetConfigData()->vectorIntConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newVectorIntSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVectorIntSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector< uint32_t > * pVariable,
-            const char* description,
-            uint32_t min, uint32_t max, bool ascending,
-            const char* condition_key, const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector< uint32_t > * pVariable,
+        const char* description,
+        uint32_t min, uint32_t max, bool ascending,
+        const char* condition_key, const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<uint32_t>>: %s\n", paramName );
-
-        json::Object newVectorIntSchema;
-        newVectorIntSchema["min"] = json::Number( min );
-        newVectorIntSchema["max"] = json::Number( max );
-        newVectorIntSchema["ascending"] = json::Number( ascending ? 1 : 0 );
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number( min );
+        newParamSchema["max"] = json::Number( max );
+        newParamSchema["ascending"] = json::Number( ascending ? 1 : 0 );
         if( _dryrun )
         {
-            newVectorIntSchema["description"] = json::String( description );
-            newVectorIntSchema["type"] = json::String( "Vector Uint32" );
-            newVectorIntSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String( description );
+            newParamSchema["type"] = json::String( "Vector Uint32" );
+            newParamSchema["default"] = json::Array();
         }
         else
         {
             GetConfigData()->vectorUint32ConfigTypeMap[paramName] = pVariable;
         }
-        updateSchemaWithCondition( newVectorIntSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVectorIntSchema;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -942,22 +916,23 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector,vector<float>>>: %s\n", paramName);
-
-        json::Object newVector2dFloatSchema;
-        newVector2dFloatSchema["min"] = json::Number(min);
-        newVector2dFloatSchema["max"] = json::Number(max);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
         if ( _dryrun )
         {
-            newVector2dFloatSchema["description"] = json::String(description);
-            newVector2dFloatSchema["type"] = json::String("Vector2d Float");
-            newVector2dFloatSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector2d Float");
+            newParamSchema[ "default" ] = json::Array();
         }
         else
         {
             GetConfigData()->vector2dFloatConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newVector2dFloatSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVector2dFloatSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -970,22 +945,23 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector,vector<int>>>: %s\n", paramName);
-
-        json::Object newVector2dIntSchema;
-        newVector2dIntSchema["min"] = json::Number(min);
-        newVector2dIntSchema["max"] = json::Number(max);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number(min);
+        newParamSchema["max"] = json::Number(max);
         if ( _dryrun )
         {
-            newVector2dIntSchema["description"] = json::String(description);
-            newVector2dIntSchema["type"] = json::String("Vector2d Int");
-            newVector2dIntSchema[ "default" ] = json::Array();
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector2d Int");
+            newParamSchema["default"] = json::Array();
         }
         else
         {
             GetConfigData()->vector2dIntConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newVector2dIntSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newVector2dIntSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     // We have sets/vectors from json arrays, now add maps from json dictonaries
@@ -999,18 +975,18 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<pwcMap>: %s\n", paramName);
-
-        json::Object newNestedSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newNestedSchema["description"] = json::String(defaultDesc);
-            newNestedSchema["type"] = json::String("nested json object (of key-value pairs)");
+            newParamSchema["description"] = json::String(defaultDesc);
+            newParamSchema["type"] = json::String("nested json object (of key-value pairs)");
         }
         else
         {
             GetConfigData()->ffMapConfigTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newNestedSchema;
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1022,19 +998,20 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<pwcMap>: %s\n", paramName);
-
-        json::Object newNestedSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newNestedSchema["description"] = json::String(description);
-            newNestedSchema["type"] = json::String("nested json object (of key-value pairs)");
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("nested json object (of key-value pairs)");
         }
         else
         {
             GetConfigData()->ffMapConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newNestedSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newNestedSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1045,18 +1022,18 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<pwcMap>: %s\n", paramName);
-
-        json::Object newNestedSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            newNestedSchema["description"] = json::String(defaultDesc);
-            newNestedSchema["type"] = json::String("nested json object (of key-value pairs)");
+            newParamSchema["description"] = json::String(defaultDesc);
+            newParamSchema["type"] = json::String("nested json object (of key-value pairs)");
         }
         else
         {
             GetConfigData()->sfMapConfigTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newNestedSchema;
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1069,22 +1046,23 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<RangedFloat>: %s\n", paramName);
-
-        json::Object newFloatSchema;
-        newFloatSchema["min"] = json::Number( pVariable->getMin() );
-        newFloatSchema["max"] = json::Number( pVariable->getMax() );
-        newFloatSchema["default"] = json::Number(defaultvalue);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number( pVariable->getMin() );
+        newParamSchema["max"] = json::Number( pVariable->getMax() );
+        newParamSchema["default"] = json::Number(defaultvalue);
         if ( _dryrun )
         {
-            newFloatSchema["description"] = json::String(description);
-            newFloatSchema["type"] = json::String( "float" );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "float" );
         }
         else
         {
             GetConfigData()->rangedFloatConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newFloatSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newFloatSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1113,22 +1091,23 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NaturalNumber>: %s\n", paramName);
-
-        json::Object newNNSchema;
-        newNNSchema["min"] = json::Number( 0 );
-        newNNSchema["max"] = json::Number( max );
-        newNNSchema["default"] = json::Number(defaultvalue);
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number( 0 );
+        newParamSchema["max"] = json::Number( max );
+        newParamSchema["default"] = json::Number(defaultvalue);
         if ( _dryrun )
         {
-            newNNSchema["description"] = json::String(description);
-            newNNSchema["type"] = json::String( "NaturalNumber" );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "NaturalNumber" );
         }
         else
         {
             GetConfigData()->naturalNumberConfigTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newNNSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newNNSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1140,32 +1119,26 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<JsonConfigurable>: %s\n", paramName);
-
-        json::Object newNestedSchema;
+        json::Object newParamSchema;
         if ( _dryrun )
         {
-            // --------------------------------------------------------
-            // --- Get the type of variable and declare it an "idmType"
-            // --------------------------------------------------------
             std::string variable_type = pVariable->GetTypeName();
             variable_type = std::string("idmType:") + variable_type ;
 
-            // ------------------------------------------------------
-            // --- Put the schema for the special type into map first
-            // --- so that its definition appears before it is used.
-            // ------------------------------------------------------
             pVariable->Configure( nullptr );
             jsonSchemaBase[ variable_type ] = pVariable->GetSchema();
 
-            newNestedSchema["description"] = json::String(defaultDesc);
-            newNestedSchema["type"] = json::String(variable_type);
+            newParamSchema["description"] = json::String(defaultDesc);
+            newParamSchema["type"] = json::String(variable_type);
         }
         else
         {
             GetConfigData()->jcTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newNestedSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newNestedSchema;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void JsonConfigurable::initConfigComplexType(
@@ -1180,9 +1153,14 @@ namespace Kernel
         json::Object newParamSchema;
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
 
+        json::QuickBuilder custom_schema = pVariable->GetSchema();
+        if (pVariable->HasValidDefault())
+        {
+            newParamSchema["default"] = custom_schema[_typeschema_label()]["default"];
+        }
+
         if( _dryrun )
         {
-            json::QuickBuilder custom_schema = pVariable->GetSchema();
             std::string custom_type_label = (std::string) custom_schema[ _typename_label() ].As<json::String>();
             json::String custom_type_label_as_json_string = json::String( custom_type_label );
 
@@ -1194,11 +1172,6 @@ namespace Kernel
             if( s_check.Exist(_typeschema_label()) )
             {
                 jsonSchemaBase[ custom_type_label ] = custom_schema[ _typeschema_label() ];
-
-                if (pVariable->HasValidDefault())
-                {
-                    newParamSchema["default"] = custom_schema[_typeschema_label()]["default"];
-                }
             }
         }
 
@@ -1209,8 +1182,7 @@ namespace Kernel
         const char* paramName,
         IComplexJsonConfigurable * pVariable,
         const char* description,
-        const char* condition_key, 
-        const char* condition_value
+        const char* condition_key, const char* condition_value
     )
     {
 
@@ -1220,7 +1192,7 @@ namespace Kernel
         //  "default" : []
         //  }
 
-        json::Object newComplexTypeSchemaEntry;
+        json::Object newParamSchema;
         if( _dryrun )
         {
             json::QuickBuilder custom_schema = pVariable->GetSchema();
@@ -1229,17 +1201,20 @@ namespace Kernel
             jsonSchemaBase[ custom_type_label ] = custom_schema[ _typeschema_label() ];
 
             std::string item_type = std::string("idmType:") + std::string(custom_schema[ "item_type" ].As<json::String>());
-            newComplexTypeSchemaEntry["description"] = json::String( description );
-            newComplexTypeSchemaEntry["type"] = json::String( std::string("Vector ") + item_type );
-            newComplexTypeSchemaEntry["item_type"] = json::String( item_type );
-            newComplexTypeSchemaEntry["default"] = json::Array();
+            newParamSchema["description"] = json::String( description );
+            newParamSchema["type"] = json::String( std::string("Vector ") + item_type );
+            newParamSchema["item_type"] = json::String( item_type );
+            newParamSchema["default"] = json::Array();
         }
         else
         {
             GetConfigData()->complexTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newComplexTypeSchemaEntry, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newComplexTypeSchemaEntry;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[ paramName ] = newParamSchema;
+
     }
 
     void
@@ -1334,13 +1309,13 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<NPKeyParameter>: %s\n", paramName);
 
-        json::Object newNPKeySchema;
-        newNPKeySchema["default"] = json::String("");
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String("");
         if( _dryrun )
         {
-            newNPKeySchema["description"] = json::String(description);
-            newNPKeySchema[ "type" ] = json::String( "Constrained String" );
-            newNPKeySchema[ "value_source" ] = json::String( NPKey::GetConstrainedStringConstraintKey() );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema[ "type" ] = json::String( "Constrained String" );
+            newParamSchema[ "value_source" ] = json::String( NPKey::GetConstrainedStringConstraintKey() );
         }
         else
         {
@@ -1350,25 +1325,25 @@ namespace Kernel
             }
             GetConfigData()->npKeyTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newNPKeySchema;
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
     JsonConfigurable::initConfigTypeMap(
         const char* paramName,
         NPKeyValueParameter * pVariable,
-        const char * description
+        const char* description
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NPKeyValueParameter>: %s\n", paramName);
 
-        json::Object newNPKeyValueSchema;
-        newNPKeyValueSchema["default"] = json::String("");
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String("");
         if( _dryrun )
         {
-            newNPKeyValueSchema["description"] = json::String(description);
-            newNPKeyValueSchema[ "type" ] = json::String( "Constrained String" );
-            newNPKeyValueSchema[ "value_source" ] = json::String( NPKey::GetConstrainedStringConstraintKeyValue() );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema[ "type" ] = json::String( "Constrained String" );
+            newParamSchema[ "value_source" ] = json::String( NPKey::GetConstrainedStringConstraintKeyValue() );
         }
         else
         {
@@ -1378,7 +1353,7 @@ namespace Kernel
             }
             GetConfigData()->npKeyValueTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newNPKeyValueSchema;
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1392,10 +1367,10 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTrigger>: %s\n", paramName );
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Constrained String" );
             qb[ "default" ] = json::String( "" );
@@ -1410,25 +1385,25 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector<EventTrigger> * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector<EventTrigger>* pVariable,
+        const char* description,
+        const char* condition_key,
+        const char* condition_value
+    )
     {
-        LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName );
+        LOG_DEBUG_F("initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName);
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Vector Constrained String" );
             qb[ "default" ] = json::Array();
@@ -1443,8 +1418,8 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerVectorTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
@@ -1458,10 +1433,10 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerNode>: %s\n", paramName );
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Constrained String" );
             qb[ "default" ] = json::String( "" );
@@ -1476,25 +1451,25 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerNodeTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector<EventTriggerNode> * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector<EventTriggerNode> * pVariable,
+        const char * description,
+        const char* condition_key,
+        const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName );
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Vector Constrained String" );
             qb[ "default" ] = json::Array();
@@ -1509,8 +1484,8 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerNodeVectorTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
@@ -1524,10 +1499,10 @@ namespace Kernel
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerCoordinator>: %s\n", paramName );
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Constrained String" );
             qb[ "default" ] = json::String( "" );
@@ -1542,25 +1517,25 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerCoordinatorTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector<EventTriggerCoordinator> * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector<EventTriggerCoordinator> * pVariable,
+        const char * description,
+        const char* condition_key,
+        const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTriggerCoordinator>>: %s\n", paramName );
 
-        json::Object newTriggerSchema;
+        json::Object newParamSchema;
         if( _dryrun )
         {
-            json::QuickBuilder qb( newTriggerSchema );
+            json::QuickBuilder qb( newParamSchema );
             qb[ "description" ] = json::String( description );
             qb[ "type" ] = json::String( "Vector Constrained String" );
             qb[ "default" ] = json::Array();
@@ -1575,8 +1550,8 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerCoordinatorVectorTypeMap[ paramName ] = pVariable;
         }
-        updateSchemaWithCondition( newTriggerSchema, condition_key, condition_value );
-        jsonSchemaBase[ paramName ] = newTriggerSchema;
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
@@ -2330,19 +2305,19 @@ namespace Kernel
         // ---------------------------------- JsonConfigurable MAP ------------------------------------
         for (auto& entry : GetConfigData()->jcTypeMap)
         {
-            const auto & key = entry.first;
-            
+            const std::string& key = entry.first;
             json::QuickInterpreter schema = jsonSchemaBase[key];
+
             if ( ignoreParameter( schema, inputJson ) )
             {
-               // param is missing and that's ok." << std::endl;
+               // param is missing and that's okay
                continue;
             }
 
-            JsonConfigurable * pJc = entry.second;
+            JsonConfigurable* pJc = entry.second;
             if( inputJson->Exist( key ) )
             {
-                Configuration * p_config = Configuration::CopyFromElement( (*inputJson)[key], inputJson->GetDataLocation() );
+                Configuration* p_config = Configuration::CopyFromElement( (*inputJson)[key], inputJson->GetDataLocation() );
 
                 pJc->Configure( p_config );
 

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -533,7 +533,8 @@ namespace Kernel
         bool * pVariable,
         const char* description,
         bool defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<bool>: %s\n", paramName);
@@ -551,6 +552,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -561,7 +569,8 @@ namespace Kernel
         int * pVariable,
         const char * description,
         int min, int max, int defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName);
@@ -581,6 +590,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -591,7 +607,8 @@ namespace Kernel
         uint32_t * pVariable,
         const char * description,
         uint32_t min, uint32_t max, uint32_t defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName );
@@ -610,6 +627,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
@@ -620,7 +644,8 @@ namespace Kernel
         uint64_t * pVariable,
         const char * description,
         uint64_t min, uint64_t max, uint64_t defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<int>: %s\n", paramName );
@@ -639,6 +664,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
@@ -649,7 +681,8 @@ namespace Kernel
         float * pVariable,
         const char * description,
         float min, float max, float defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<float>: %s\n", paramName);
@@ -668,6 +701,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -678,7 +718,8 @@ namespace Kernel
         double * pVariable,
         const char * description,
         double min, double max, double defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<double>: %s\n", paramName);
@@ -698,6 +739,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -708,7 +756,8 @@ namespace Kernel
         std::string * pVariable,
         const char * description,
         const std::string& default_str,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<string>: %s\n", paramName);
@@ -725,6 +774,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -735,7 +791,8 @@ namespace Kernel
         jsonConfigurable::ConstrainedString * pVariable,
         const char * description,
         const std::string& default_str,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<ConstrainedString>: %s\n", paramName);
@@ -753,6 +810,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -763,7 +827,8 @@ namespace Kernel
         const char* paramName,
         jsonConfigurable::tStringSetBase * pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<set<string>>: %s\n", paramName);
@@ -798,6 +863,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -809,7 +881,8 @@ namespace Kernel
         const char* description,
         const char* constraint_schema,
         const std::set< std::string > &constraint_variable,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<string>>: %s\n", paramName);
@@ -832,6 +905,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -843,7 +923,8 @@ namespace Kernel
         const char* description,
         const char* constraint_schema,
         const std::set< std::string > &constraint_variable,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<string>>>: %s\n", paramName);
@@ -865,6 +946,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -875,7 +963,8 @@ namespace Kernel
         const char* description,
         const char* constraint_schema,
         const std::set< std::string > &constraint_variable,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
         )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<vector<string>>>>: %s\n", paramName);
@@ -898,6 +987,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
         jsonSchemaBase[paramName] = newParamSchema;
     }
 
@@ -907,7 +1003,8 @@ namespace Kernel
         std::vector< std::vector< std::vector<float> > > * pVariable,
         const char* description,
         float min, float max,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<vector<vector<float>>>: %s\n", paramName );
@@ -926,6 +1023,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -936,7 +1040,8 @@ namespace Kernel
         std::vector< float > * pVariable,
         const char* description,
         float min, float max, bool ascending,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<vector<float>>: %s\n", paramName);
@@ -956,6 +1061,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -965,7 +1077,8 @@ namespace Kernel
         const char* paramName,
         std::vector< bool > * pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<bool>>: %s\n", paramName);
@@ -979,6 +1092,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -989,7 +1109,8 @@ namespace Kernel
         std::vector< int > * pVariable,
         const char* description,
         int min, int max, bool ascending,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<int>>: %s\n", paramName);
@@ -1009,6 +1130,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1019,7 +1147,8 @@ namespace Kernel
         std::vector< uint32_t > * pVariable,
         const char* description,
         uint32_t min, uint32_t max, bool ascending,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector<uint32_t>>: %s\n", paramName );
@@ -1039,6 +1168,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1049,7 +1185,8 @@ namespace Kernel
         std::vector< std::vector< float > > * pVariable,
         const char* description,
         float min, float max,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector,vector<float>>>: %s\n", paramName);
@@ -1068,6 +1205,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1078,7 +1222,8 @@ namespace Kernel
         std::vector< std::vector< int > > * pVariable,
         const char* description,
         int min, int max,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<vector,vector<int>>>: %s\n", paramName);
@@ -1097,6 +1242,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1131,7 +1283,8 @@ namespace Kernel
         const char* paramName,
         tFloatFloatMapConfigType * pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<pwcMap>: %s\n", paramName);
@@ -1147,6 +1300,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1179,7 +1339,8 @@ namespace Kernel
         RangedFloat * pVariable,
         const char * description,
         float defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<RangedFloat>: %s\n", paramName);
@@ -1198,6 +1359,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1209,7 +1377,8 @@ namespace Kernel
         const char * description,
         float max,
         float defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NonNegativeFloat>: %s\n", paramName);
@@ -1225,6 +1394,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1237,7 +1413,8 @@ namespace Kernel
         const char * description,
         unsigned int max,
         NaturalNumber defaultvalue,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NaturalNumber>: %s\n", paramName);
@@ -1256,6 +1433,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1265,7 +1449,8 @@ namespace Kernel
         const char* paramName,
         JsonConfigurable * pVariable,
         const char* defaultDesc,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<JsonConfigurable>: %s\n", paramName);
@@ -1287,6 +1472,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1295,13 +1487,21 @@ namespace Kernel
         const char* paramName,
         IComplexJsonConfigurable* pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         GetConfigData()->complexTypeMap[ paramName ] = pVariable;
 
         json::Object newParamSchema;
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         json::QuickBuilder custom_schema = pVariable->GetSchema();
         if (pVariable->HasValidDefault())
@@ -1332,7 +1532,8 @@ namespace Kernel
         const char* paramName,
         IComplexJsonConfigurable * pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
 
@@ -1362,6 +1563,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
@@ -1443,7 +1651,8 @@ namespace Kernel
         const char* paramName,
         std::vector<IPKeyValueParameter>* pVariable,
         const char* description,
-        const char* condition_key, const char* condition_value
+        const char* condition_key, const char* condition_value,
+        const std::map<std::string, std::string>* depends_list
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<vector<IPKeyValueParameter>>: %s\n", paramName);
@@ -1461,6 +1670,13 @@ namespace Kernel
         }
 
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
 
         jsonSchemaBase[paramName] = newParamSchema;
     }

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -370,16 +370,21 @@ namespace Kernel
         LOG_DEBUG_F( "Setting condition in schema for key %s (value=%s).\n", condition_key, ( condition_value ? condition_value : "1") );
         if( condition_key )
         {
-            json::Object condition;
-            if( condition_value )
+            if(!schema.Exist("depends-on"))
             {
-                condition[ condition_key ] = json::String( condition_value );
+                schema["depends-on"] = json::Object();
+            }
+
+            if( condition_value == nullptr )
+            {
+                // condition_value is null, so condition_key is a bool and condition_value is implicitly true
+                json_cast<json::Object&>(schema["depends-on"])[ condition_key ] = json::Number( 1 );
             }
             else
-            { 
-                condition[ condition_key ] = json::Number( 1 );
+            {
+                // condition_value is not null, so it's a string (enum)
+                json_cast<json::Object&>(schema["depends-on"])[ condition_key ] = json::String( condition_value );
             }
-            schema["depends-on"] = condition;
         }
     }
 

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -1307,7 +1307,7 @@ namespace Kernel
         json::QuickBuilder custom_schema = pVariable->GetSchema();
         if (pVariable->HasValidDefault())
         {
-            newParamSchema["default"] = custom_schema[_typeschema_label()]["default"];
+            newParamSchema["default"] = custom_schema["default"];
         }
 
         if( _dryrun )

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -414,6 +414,11 @@ namespace Kernel
                 // condition_value is null, so condition_key is a bool and condition_value is implicitly true
                 json_cast<json::Object&>(schema["depends-on"])[ condition_key ] = json::Number( 1 );
             }
+            else if( (std::string(condition_key)).rfind("Enable_", 0) == 0 )
+            {
+                // condition_key starts with "Enable_", so condition_key is a bool
+                json_cast<json::Object&>(schema["depends-on"])[ condition_key ] = json::Number( std::stoi(std::string(condition_value),nullptr) );
+            }
             else
             {
                 // condition_value is not null, so it's a string (enum)

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -1737,7 +1737,6 @@ namespace Kernel
             {
                 errMsg << "\t \"" << key.c_str() << "\"" << std::endl;
             }
-            //LOG_ERR( errMsg.str().c_str() );
             throw GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, errMsg.str().c_str() );
         }
     }

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -1,7 +1,6 @@
 
 #include "stdafx.h"
 #include "Configuration.h"
-#include "ConfigurationImpl.h"
 #include "Configure.h"
 #include "Exceptions.h"
 #include "IdmString.h"
@@ -49,7 +48,6 @@ namespace Kernel
                 }
                 else
                 {
-                    release_assert( condition_value );
                     // condition_value is not null, so it's a string (enum); let's read it.
                     auto c_value_from_config = (std::string) c_value.As<json::String>();
                     LOG_DEBUG_F( "string/enum condition_value (from config.json) = %s. Will check if matches schema condition_value (raw) = %s\n", c_value_from_config.c_str(), condition_value );
@@ -417,6 +415,11 @@ namespace Kernel
         m_pData = nullptr;
     }
 
+    IConfigurable* JsonConfigurable::GetConfigurable()
+    {
+        return static_cast<IConfigurable*>(this);
+    }
+
     std::string JsonConfigurable::GetTypeName() const
     {
         std::string variable_type = typeid(*this).name();
@@ -458,6 +461,30 @@ namespace Kernel
     json::Object& JsonConfigurable::GetSchemaBase()
     {
         return jsonSchemaBase;
+    }
+
+    bool JsonConfigurable::MatchesDependency(const json::QuickInterpreter*              pJson,
+                                             const char*                                condition_key,
+                                             const char*                                condition_value,
+                                             const std::map<std::string, std::string>*  depends_list)
+    {
+        json::Object newParamSchema;
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+        if(depends_list)
+        {
+            for(auto const pair: *depends_list)
+            {
+                updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+            }
+        }
+
+        if(ignoreParameter(newParamSchema, pJson))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     void
@@ -829,6 +856,7 @@ namespace Kernel
             GetConfigData()->vector3dStringConfigTypeMap[ paramName ] = pVariable;
             GetConfigData()->vector3dStringConstraintsTypeMap[ paramName ] = &constraint_variable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
         jsonSchemaBase[paramName] = newParamSchema;
     }
@@ -1144,8 +1172,21 @@ namespace Kernel
         const char* condition_key, const char* condition_value
     )
     {
-        RangedFloat * pTmp = (RangedFloat*) pVariable;
-        return initConfigTypeMap( paramName, pTmp, description, defaultvalue, condition_key, condition_value );
+        LOG_DEBUG_F( "initConfigTypeMap<NonNegativeFloat>: %s\n", paramName);
+        GetConfigData()->nonNegativeFloatConfigTypeMap[ paramName ] = pVariable;
+        json::Object newParamSchema;
+        newParamSchema["min"] = json::Number( pVariable->getMin() );
+        newParamSchema["max"] = json::Number( pVariable->getMax() );
+        newParamSchema["default"] = json::Number(defaultvalue);
+        if ( _dryrun )
+        {
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String( "float" );
+        }
+
+        updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
 
@@ -1294,14 +1335,13 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<IPKeyParameter>: %s\n", paramName);
-
-        json::Object newIPKeySchema;
-        newIPKeySchema["default"] = json::String("");
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String("");
         if( _dryrun )
         {
-            newIPKeySchema["description"] = json::String(description);
-            newIPKeySchema["type"] = json::String("Constrained String");
-            newIPKeySchema[ "value_source" ] = json::String( IPKey::GetConstrainedStringConstraintKey() );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Constrained String");
+            newParamSchema[ "value_source" ] = json::String( IPKey::GetConstrainedStringConstraintKey() );
         }
         else
         {
@@ -1311,7 +1351,8 @@ namespace Kernel
             }
             GetConfigData()->ipKeyTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newIPKeySchema;
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1322,14 +1363,13 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<IPKeyValueParameter>: %s\n", paramName);
-
-        json::Object newIPKeyValueSchema;
-        newIPKeyValueSchema["default"] = json::String("");
+        json::Object newParamSchema;
+        newParamSchema["default"] = json::String("");
         if( _dryrun )
         {
-            newIPKeyValueSchema["description"] = json::String(description);
-            newIPKeyValueSchema[ "type" ] = json::String( "Constrained String" );
-            newIPKeyValueSchema[ "value_source" ] = json::String( IPKey::GetConstrainedStringConstraintKeyValue() );
+            newParamSchema["description"] = json::String(description);
+            newParamSchema[ "type" ] = json::String( "Constrained String" );
+            newParamSchema[ "value_source" ] = json::String( IPKey::GetConstrainedStringConstraintKeyValue() );
         }
         else
         {
@@ -1339,34 +1379,35 @@ namespace Kernel
             }
             GetConfigData()->ipKeyValueTypeMap[ paramName ] = pVariable;
         }
-        jsonSchemaBase[paramName] = newIPKeyValueSchema;
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            std::vector<IPKeyValueParameter>* pVariable,
-            const char* description,
-            const char* condition_key,
-            const char* condition_value
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        std::vector<IPKeyValueParameter>* pVariable,
+        const char* description,
+        const char* condition_key, const char* condition_value
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<vector<IPKeyValueParameter>>: %s\n", paramName);
-
-        json::Object newIPKeyValueSchema;
+        json::Object newParamSchema;
         if (_dryrun)
         {
-            newIPKeyValueSchema["description"] = json::String(description);
-            newIPKeyValueSchema["type"] = json::String("Vector Constrained String");
-            newIPKeyValueSchema[ "default" ] = json::Array();
-            newIPKeyValueSchema["value_source"] = json::String(IPKey::GetConstrainedStringConstraintKeyValue());
+            newParamSchema["description"] = json::String(description);
+            newParamSchema["type"] = json::String("Vector Constrained String");
+            newParamSchema[ "default" ] = json::Array();
+            newParamSchema["value_source"] = json::String(IPKey::GetConstrainedStringConstraintKeyValue());
         }
         else
         {
             GetConfigData()->iPKeyValueVectorMapType[paramName] = pVariable;
         }
-        updateSchemaWithCondition( newIPKeyValueSchema, condition_key, condition_value );
-        jsonSchemaBase[paramName] = newIPKeyValueSchema;
+
+        updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
+        jsonSchemaBase[paramName] = newParamSchema;
     }
 
     void
@@ -1377,7 +1418,6 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NPKeyParameter>: %s\n", paramName);
-
         json::Object newParamSchema;
         newParamSchema["default"] = json::String("");
         if( _dryrun )
@@ -1394,6 +1434,7 @@ namespace Kernel
             }
             GetConfigData()->npKeyTypeMap[ paramName ] = pVariable;
         }
+
         jsonSchemaBase[paramName] = newParamSchema;
     }
 
@@ -1405,7 +1446,6 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<NPKeyValueParameter>: %s\n", paramName);
-
         json::Object newParamSchema;
         newParamSchema["default"] = json::String("");
         if( _dryrun )
@@ -1422,6 +1462,7 @@ namespace Kernel
             }
             GetConfigData()->npKeyValueTypeMap[ paramName ] = pVariable;
         }
+
         jsonSchemaBase[paramName] = newParamSchema;
     }
 
@@ -1435,7 +1476,6 @@ namespace Kernel
         )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTrigger>: %s\n", paramName );
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1454,7 +1494,9 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
@@ -1468,7 +1510,6 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F("initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName);
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1487,21 +1528,22 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerVectorTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            EventTriggerNode * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        EventTriggerNode * pVariable,
+        const char * description,
+        const char* condition_key,
+        const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerNode>: %s\n", paramName );
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1520,7 +1562,9 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerNodeTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[paramName] = newParamSchema;
     }
 
@@ -1534,7 +1578,6 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTrigger>>: %s\n", paramName );
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1553,21 +1596,22 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerNodeVectorTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
     void
-        JsonConfigurable::initConfigTypeMap(
-            const char* paramName,
-            EventTriggerCoordinator * pVariable,
-            const char * description,
-            const char* condition_key,
-            const char* condition_value
-        )
+    JsonConfigurable::initConfigTypeMap(
+        const char* paramName,
+        EventTriggerCoordinator * pVariable,
+        const char * description,
+        const char* condition_key,
+        const char* condition_value
+    )
     {
         LOG_DEBUG_F( "initConfigTypeMap<EventTriggerCoordinator>: %s\n", paramName );
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1586,7 +1630,9 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerCoordinatorTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
@@ -1600,7 +1646,6 @@ namespace Kernel
     )
     {
         LOG_DEBUG_F( "initConfigTypeMap<std::vector<EventTriggerCoordinator>>: %s\n", paramName );
-
         json::Object newParamSchema;
         if( _dryrun )
         {
@@ -1619,7 +1664,9 @@ namespace Kernel
         {
             GetConfigData()->eventTriggerCoordinatorVectorTypeMap[ paramName ] = pVariable;
         }
+
         updateSchemaWithCondition( newParamSchema, condition_key, condition_value );
+
         jsonSchemaBase[ paramName ] = newParamSchema;
     }
 
@@ -1925,6 +1972,46 @@ namespace Kernel
 
         // ---------------------------------- RANGEDFLOAT ------------------------------------
         for (auto& entry : GetConfigData()->rangedFloatConfigTypeMap)
+        {
+            const std::string& key = entry.first;
+            json::QuickInterpreter schema = jsonSchemaBase[key];
+            float val = -1.0f;
+
+            if( ignoreParameter( schema, inputJson ) )
+            {
+                continue; // param is missing and that's ok.
+            }
+
+            // Check if parameter was specified in input json
+            LOG_DEBUG_F( "useDefaults = %d\n", _useDefaults );
+            if( inputJson->Exist(key) )
+            {
+                // get specified configuration parameter
+                val = GET_CONFIG_DOUBLE( inputJson, key.c_str() );
+                *(entry.second) = val;
+                // throw exception if specified value is outside of range even though this datatype enforces ranges inherently.
+                EnforceParameterRange<float>( key, val, schema);
+            }
+            else
+            {
+                if( _useDefaults )
+                {
+                    // using the default value
+                    val = (float)schema["default"].As<json::Number>();
+                    LOG_DEBUG_F( "Using the default value ( \"%s\" : %f ) for unspecified parameter.\n", key.c_str(), val );
+                    *(entry.second) = val;
+                }
+                else 
+                {
+                    handleMissingParam( key, inputJson->GetDataLocation() );
+                }
+            }
+
+            LOG_DEBUG_F("the key %s = float %f\n", key.c_str(), (float) *(entry.second));
+        }
+
+        // ---------------------------------- NONNEGATIVEFLOAT ------------------------------------
+        for (auto& entry : GetConfigData()->nonNegativeFloatConfigTypeMap)
         {
             const std::string& key = entry.first;
             json::QuickInterpreter schema = jsonSchemaBase[key];

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -865,13 +865,18 @@ namespace Kernel
     {
         public:
             IndividualInterventionConfig();
-            virtual json::QuickBuilder GetSchema();
+            IndividualInterventionConfig(json::QuickInterpreter* qi);
+
+            virtual json::QuickBuilder GetSchema() override;
     };
 
     class NodeInterventionConfig : public InterventionConfig
     {
         public:
-            virtual json::QuickBuilder GetSchema();
+            NodeInterventionConfig();
+            NodeInterventionConfig(json::QuickInterpreter* qi);
+
+            virtual json::QuickBuilder GetSchema() override;
     };
 
     class NodeSetConfig : public JsonConfigurable, public IComplexJsonConfigurable

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -126,6 +126,7 @@ namespace Kernel
         typedef std::map< std::string, ConstrainedString * > tConStringConfigTypeMapType;
     }
 
+    bool ignoreParameter( const json::QuickInterpreter& schema, const json::QuickInterpreter * pJson );
     bool ignoreParameter( const json::QuickInterpreter * pJson, const char * condition_key, const char * condition_value = nullptr );
 
     class JsonConfigurable : public IConfigurable
@@ -152,6 +153,7 @@ namespace Kernel
         static const char * default_string;
 
         static void CheckMissingParameters();
+        virtual IConfigurable* GetConfigurable() override;
 
     private:
         typedef std::map< std::string, bool * > tBoolConfigTypeMapType;
@@ -218,6 +220,11 @@ namespace Kernel
 
         static jsonConfigurable::tStringSet missing_parameters_set;
 
+        bool MatchesDependency(const json::QuickInterpreter*              pJson,
+                               const char*                                condition_key   = nullptr,
+                               const char*                                condition_value = nullptr,
+                               const std::map<std::string, std::string>*  depends_list    = nullptr);
+
         // TEST ONLY - componentTests needs to clear this so that other tests don't fail
         static void ClearMissingParameters() { missing_parameters_set.clear() ; }
 
@@ -265,7 +272,6 @@ namespace Kernel
             tEventTriggerNodeVectorMapType eventTriggerNodeVectorTypeMap;
             tEventTriggerCoordinatorMapType eventTriggerCoordinatorTypeMap;
             tEventTriggerCoordinatorVectorMapType eventTriggerCoordinatorVectorTypeMap;
-
         };
     private:
         // make this private so subclasses have to call GetConfigData()
@@ -581,7 +587,7 @@ namespace Kernel
             const char* condition_value = nullptr
         );
 
-       template< typename T >
+        template< typename T >
         void EnforceParameterRange( const std::string& key, T value, json::QuickInterpreter& jsonObj )
         {
             T min = (T)jsonObj["min"].As<json::Number>();
@@ -604,13 +610,16 @@ namespace Kernel
         void EnforceParameterAscending(const std::string& key, const std::vector<T> & values)
         {
             //Try to find a value to the left of an element with a value that is greater or equal 
-            for( int i = 0; i < int(values.size())-1; ++i )
+            if( values.size() > 1 )
             {
-                if( values[ i ] >= values[ i + 1 ] )
+                for (auto it = values.cbegin(); it != values.cend() - 1; ++it)
                 {
-                    std::stringstream error_string;
-                    error_string << "The values in '" << key << "' must be unique and in ascending order.";
-                    throw InvalidInputDataException(__FILE__, __LINE__, __FUNCTION__, error_string.str().c_str());
+                    if (*it >= *(it + 1))
+                    {
+                        std::stringstream error_string;
+                        error_string << "The values in '" << key << "' must be unique and in ascending order.";
+                        throw InvalidInputDataException(__FILE__, __LINE__, __FUNCTION__, error_string.str().c_str());
+                    }
                 }
             }
         }

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -19,6 +19,8 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <iterator>
+#include <climits>
 
 #ifndef WIN32
 #include <limits>
@@ -268,8 +270,8 @@ namespace Kernel
             tIPKeyValueVectorMapType iPKeyValueVectorMapType;
             tNPKeyMapType npKeyTypeMap ;
             tNPKeyValueMapType npKeyValueTypeMap;
-            tEventTriggerMapType eventTriggerTypeMap ;
-            tEventTriggerVectorMapType eventTriggerVectorTypeMap ;
+            tEventTriggerMapType eventTriggerTypeMap;
+            tEventTriggerVectorMapType eventTriggerVectorTypeMap;
             tEventTriggerNodeMapType eventTriggerNodeTypeMap;
             tEventTriggerNodeVectorMapType eventTriggerNodeVectorTypeMap;
             tEventTriggerCoordinatorMapType eventTriggerCoordinatorTypeMap;
@@ -311,7 +313,8 @@ namespace Kernel
             bool * pVariable,
             const char* description = default_description,
             bool defaultvalue = false,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -319,7 +322,8 @@ namespace Kernel
             int * pVariable,
             const char* description = default_description,
             int min = INT_MIN, int max = INT_MAX, int defaultvalue = 0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -327,7 +331,8 @@ namespace Kernel
             uint32_t * pVariable,
             const char* description = default_description,
             uint32_t min = 0, uint32_t max = UINT_MAX, uint32_t defaultvalue = 0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -335,7 +340,8 @@ namespace Kernel
             uint64_t * pVariable,
             const char* description = default_description,
             uint64_t min = 0, uint64_t max = UINT_MAX, uint64_t defaultvalue = 0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -343,7 +349,8 @@ namespace Kernel
             float * pVariable,
             const char* description = default_description,
             float min = -FLT_MAX, float max = FLT_MAX, float defaultvalue = 1.0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -351,7 +358,8 @@ namespace Kernel
             double * pVariable,
             const char* description = default_description,
             double min = -DBL_MAX, double max = DBL_MAX, double defaultvalue = 1.0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -359,7 +367,8 @@ namespace Kernel
             std::string * pVariable,
             const char* description = default_description,
             const std::string& default_str = default_string,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -367,14 +376,16 @@ namespace Kernel
             jsonConfigurable::ConstrainedString * pVariable,
             const char* description = default_description,
             const std::string& default_str = default_string,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
             const char* paramName,
             jsonConfigurable::tStringSetBase * pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -383,7 +394,8 @@ namespace Kernel
             const char* description = default_description,
             const char* constraint_schema = nullptr,
             const std::set< std::string > &constraint_variable = empty_set,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -392,7 +404,8 @@ namespace Kernel
             const char* description = default_description,
             const char* constraint_schema = nullptr,
             const std::set< std::string > &constraint_variable = empty_set,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -401,7 +414,8 @@ namespace Kernel
             const char* description = default_description,
             const char* constraint_schema = nullptr,
             const std::set< std::string > &constraint_variable = empty_set,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -409,14 +423,16 @@ namespace Kernel
             std::vector< float > * pVariable,
             const char* description = default_description,
             float min = -FLT_MAX, float max = FLT_MAX, bool ascending = false,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
             const char* paramName,
             std::vector< bool > * pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -424,7 +440,8 @@ namespace Kernel
             std::vector< int > * pVariable,
             const char* description = default_description,
             int min = -INT_MAX, int max = INT_MAX, bool ascending = false,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -432,7 +449,8 @@ namespace Kernel
             std::vector< uint32_t > * pVariable,
             const char* description = default_description,
             uint32_t min = 0, uint32_t max = UINT32_MAX, bool ascending = false,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -440,14 +458,16 @@ namespace Kernel
             std::vector< std::vector< float > > * pVariable,
             const char* description = default_description,
             float min = -FLT_MAX, float max = FLT_MAX,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap( const char* paramName,
             std::vector< std::vector< std::vector<float> > > * pVariable,
             const char* description = default_description,
             float min = -FLT_MAX, float max = FLT_MAX,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -455,7 +475,8 @@ namespace Kernel
             std::vector< std::vector< int > > * pVariable,
             const char* description = default_description,
             int min = -INT_MAX, int max = INT_MAX,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -468,7 +489,8 @@ namespace Kernel
             const char* paramName,
             tFloatFloatMapConfigType * pVariable,
             const char* description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -482,7 +504,8 @@ namespace Kernel
             RangedFloat * pVariable,
             const char* description = default_description,
             float defaultvalue = 1.0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -491,7 +514,8 @@ namespace Kernel
             const char* description = default_description,
             float max = 1.0,
             float defaultvalue = 1.0,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -500,14 +524,16 @@ namespace Kernel
             const char* description = default_description,
             unsigned int max = INT_MAX,
             NaturalNumber defaultvalue = 1,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
             const char* paramName,
             JsonConfigurable * pVariable,
             const char* defaultDesc,
-            const char* condition_key=nullptr, const char* condition_value=nullptr
+            const char* condition_key=nullptr, const char* condition_value=nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -526,7 +552,8 @@ namespace Kernel
             const char* paramName,
             std::vector<IPKeyValueParameter>* pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         void initConfigTypeMap(
@@ -660,13 +687,22 @@ namespace Kernel
             myclass &thevar,
             const Configuration * pJson,
             const MetadataDescriptor::Enum &enum_md,
-            const char* condition_key = nullptr, const char * condition_value = nullptr
+            const char* condition_key = nullptr, const char * condition_value = nullptr,
+            const std::map<std::string, std::string> * depends_list = nullptr
         )
         {
             MetadataDescriptor::Enum * pEnumMd = const_cast<MetadataDescriptor::Enum *>(&enum_md);
             json::Object newParamSchema = json_cast<const json::Object&>(pEnumMd->GetSchemaElement());
 
             updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+            if(depends_list)
+            {
+                for(auto const pair: *depends_list)
+                {
+                    updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+                }
+            }
+
             jsonSchemaBase[key] = newParamSchema;
 
             if( ignoreParameter( newParamSchema, pJson ) )
@@ -744,13 +780,22 @@ namespace Kernel
             std::vector<myclass> &thevector,
             const json::QuickInterpreter * pJson,
             const MetadataDescriptor::Enum &enum_md,
-            const char* condition_key = nullptr, const char * condition_value = nullptr
+            const char* condition_key = nullptr, const char * condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         )
         {
             MetadataDescriptor::Enum * pEnumMd = const_cast<MetadataDescriptor::Enum *>(&enum_md);
             json::Object newParamSchema = json_cast<const json::Object&>(pEnumMd->GetSchemaElement());
 
             updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+            if(depends_list)
+            {
+                for(auto const pair: *depends_list)
+                {
+                    updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
+                }
+            }
+
             jsonSchemaBase[key] = newParamSchema;
 
             if( ignoreParameter( newParamSchema, pJson ) )
@@ -843,7 +888,8 @@ namespace Kernel
             const char* paramName,
             IComplexJsonConfigurable * pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         // This is really for objects that are based on the JsonConfigurableColleciton
@@ -852,7 +898,8 @@ namespace Kernel
             const char* paramName,
             IComplexJsonConfigurable * pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr, const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr,
+            const std::map<std::string, std::string>* depends_list = nullptr
         );
 
         virtual bool Configure( const Configuration* inputJson );

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -129,6 +129,8 @@ namespace Kernel
     bool ignoreParameter( const json::QuickInterpreter& schema, const json::QuickInterpreter * pJson );
     bool ignoreParameter( const json::QuickInterpreter * pJson, const char * condition_key, const char * condition_value = nullptr );
 
+    void updateSchemaWithCondition( json::Object& schema, const char* condition_key, const char* condition_value );
+
     class JsonConfigurable : public IConfigurable
     {
         friend class InterventionFactory;
@@ -661,29 +663,13 @@ namespace Kernel
             const char* condition_key = nullptr, const char * condition_value = nullptr
         )
         {
-            if( JsonConfigurable::_dryrun )
-            {
-                MetadataDescriptor::Enum * pEnumMd = const_cast<MetadataDescriptor::Enum *>(&enum_md);
-                json::Element *elem_copy = _new_ json::Element(pEnumMd->GetSchemaElement());
-                auto enumSchema = json::QuickBuilder( *elem_copy );
+            MetadataDescriptor::Enum * pEnumMd = const_cast<MetadataDescriptor::Enum *>(&enum_md);
+            json::Object newParamSchema = json_cast<const json::Object&>(pEnumMd->GetSchemaElement());
 
-                if( condition_key )
-                {
-                    json::Object condition;
-                    if( condition_value == nullptr )
-                    {
-                        condition[ condition_key ] = json::Number( 1 );
-                    }
-                    else
-                    {
-                        condition[ condition_key ] = json::String( condition_value );
-                    }
-                    enumSchema["depends-on"] = condition;
-                }
-                jsonSchemaBase[key] = enumSchema;
-            }
+            updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+            jsonSchemaBase[key] = newParamSchema;
 
-            if( ignoreParameter( pJson, condition_key, condition_value ) )
+            if( ignoreParameter( newParamSchema, pJson ) )
             {
                 return true; // param is missing and that's ok.
             }
@@ -692,7 +678,7 @@ namespace Kernel
             {
                 if( _useDefaults )
                 {
-                    if( (EnvPtr != nullptr) && EnvPtr->Log->CheckLogLevel(Logger::INFO, "JsonConfigurable"))
+                    if( (EnvPtr != nullptr) && EnvPtr->Log->CheckLogLevel(Logger::DEBUG, "JsonConfigurable"))
                     {
                         EnvPtr->Log->Log(Logger::DEBUG, "JsonConfigurable", "Using the default value ( \"%s\" : \"%s\" ) for unspecified parameter.\n", key, enum_md.enum_value_specs[0].first.c_str() );
                     }
@@ -737,16 +723,14 @@ namespace Kernel
                                      << " and key "
                                      << "'" << key << "'.\n"
                                      << "Possible values are:\n";
+                    std::vector< std::string > enum_key_list;
 
-                    for( int i = 0; i < enum_md.enum_value_specs.size(); ++i )
+                    for (auto& vs : enum_md.enum_value_specs)
                     {
-                        errorMsgFullList << enum_md.enum_value_specs[ i ].first;
-                        if( (i+1) < enum_md.enum_value_specs.size())
-                        {
-                            errorMsgFullList << "\n";
-                        }
+                        enum_key_list.push_back( vs.first );
                     }
-
+                    std::copy(enum_key_list.begin(), enum_key_list.end() - 1, std::ostream_iterator<std::string>(errorMsgFullList, ", "));
+                    errorMsgFullList << enum_key_list.back();
                     throw Kernel::GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, errorMsgFullList.str().c_str() );
                 }
             }
@@ -759,24 +743,30 @@ namespace Kernel
             const char* key,
             std::vector<myclass> &thevector,
             const json::QuickInterpreter * pJson,
-            const MetadataDescriptor::Enum &enum_md
+            const MetadataDescriptor::Enum &enum_md,
+            const char* condition_key = nullptr, const char * condition_value = nullptr
         )
         {
             MetadataDescriptor::Enum * pEnumMd = const_cast<MetadataDescriptor::Enum *>(&enum_md);
-            if ( _dryrun )
+            json::Object newParamSchema = json_cast<const json::Object&>(pEnumMd->GetSchemaElement());
+
+            updateSchemaWithCondition(newParamSchema, condition_key, condition_value);
+            jsonSchemaBase[key] = newParamSchema;
+
+            if( ignoreParameter( newParamSchema, pJson ) )
             {
-                jsonSchemaBase[key] = pEnumMd->GetSchemaElement();
+                return true; // param is missing and that's ok.
             }
 
-            // parsing: unspecified case
             if (pJson && pJson->Exist(key) == false && _useDefaults )
             {
-                if ((EnvPtr != nullptr) && EnvPtr->Log->CheckLogLevel(Logger::INFO, "JsonConfigurable"))
+                if ((EnvPtr != nullptr) && EnvPtr->Log->CheckLogLevel(Logger::DEBUG, "JsonConfigurable"))
                 {
                     release_assert(thevector.empty()); // the default is empty vector
                     std::string default_in_string= "[]";
                     EnvPtr->Log->Log(Logger::DEBUG, "JsonConfigurable", "Using the default value ( \"%s\" : \"%s\" ) for unspecified parameter.\n", key, default_in_string.c_str());
                 }
+
                 return true;
             }
 
@@ -815,7 +805,15 @@ namespace Kernel
                                          << lower
                                          << " and key "
                                          << key
-                                         << ".";
+                                         << ". Possible values are: ";
+                        std::vector< std::string > enum_key_list;
+
+                        for (auto& vs : enum_md.enum_value_specs)
+                        {
+                            enum_key_list.push_back( vs.first );
+                        }
+                        std::copy(enum_key_list.begin(), enum_key_list.end() - 1, std::ostream_iterator<std::string>(errorMsgFullList, ", "));
+                        errorMsgFullList << enum_key_list.back();
                         throw Kernel::GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, errorMsgFullList.str().c_str() );
                     }
                 }

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -191,7 +191,6 @@ namespace Kernel
         typedef std::map< std::string, std::vector<EventTriggerCoordinator> * > tEventTriggerCoordinatorVectorMapType;
 
     public:
-        //IConfigurable
         virtual json::QuickBuilder GetSchema() override;
         virtual json::Array GetSimTypes() override;
         virtual void ClearSchema() override;
@@ -209,7 +208,7 @@ namespace Kernel
         static const char* _typename_label() { return "type_name"; }
         static const char* _typeschema_label()  { return "type_schema"; }
 
-        struct IDMAPI Registrator
+        struct Registrator
         {
             Registrator( const char* class_name, get_schema_funcptr_t gs_callback );
         };
@@ -430,151 +429,137 @@ namespace Kernel
             const char* condition_key = nullptr, const char* condition_value = nullptr
         );
 
-        void
-        initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             tFloatFloatMapConfigType * pVariable,
             const char* defaultDesc
         );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             tFloatFloatMapConfigType * pVariable,
             const char* description,
             const char* condition_key, const char* condition_value
-       );
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             tStringFloatMapConfigType * pVariable,
             const char* defaultDesc
-       );
+        );
 
-       void initConfigTypeMap(
-           const char* paramName,
-           RangedFloat * pVariable,
-           const char* description = default_description,
-           float defaultvalue = 1.0,
-           const char* condition_key = nullptr, const char* condition_value = nullptr
-       );
+        void initConfigTypeMap(
+            const char* paramName,
+            RangedFloat * pVariable,
+            const char* description = default_description,
+            float defaultvalue = 1.0,
+            const char* condition_key = nullptr, const char* condition_value = nullptr
+        );
 
-       void initConfigTypeMap(
-           const char* paramName,
-           NonNegativeFloat * pVariable,
-           const char* description = default_description,
-           float max = 1.0,
-           float defaultvalue = 1.0,
-           const char* condition_key = nullptr, const char* condition_value = nullptr
-       );
+        void initConfigTypeMap(
+            const char* paramName,
+            NonNegativeFloat * pVariable,
+            const char* description = default_description,
+            float max = 1.0,
+            float defaultvalue = 1.0,
+            const char* condition_key = nullptr, const char* condition_value = nullptr
+        );
 
-       void initConfigTypeMap(
-           const char* paramName,
-           NaturalNumber * pVariable,
-           const char* description = default_description,
-           unsigned int max = INT_MAX,
-           NaturalNumber defaultvalue = 1,
-           const char* condition_key = nullptr, const char* condition_value = nullptr
-       );
+        void initConfigTypeMap(
+            const char* paramName,
+            NaturalNumber * pVariable,
+            const char* description = default_description,
+            unsigned int max = INT_MAX,
+            NaturalNumber defaultvalue = 1,
+            const char* condition_key = nullptr, const char* condition_value = nullptr
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             JsonConfigurable * pVariable,
             const char* defaultDesc,
             const char* condition_key=nullptr, const char* condition_value=nullptr
-       );
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             IPKeyParameter * pVariable,
             const char* defaultDesc
-       );
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             IPKeyValueParameter * pVariable,
             const char* defaultDesc
-       );
+        );
 
-      void initConfigTypeMap(
-          const char* paramName,
-          std::vector<IPKeyValueParameter>* pVariable,
-          const char* description = default_description,
-          const char* condition_key = nullptr,
-          const char* condition_value = nullptr
-       );
+        void initConfigTypeMap(
+            const char* paramName,
+            std::vector<IPKeyValueParameter>* pVariable,
+            const char* description = default_description,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             NPKeyParameter * pVariable,
             const char* defaultDesc
-       );
+        );
 
-       void
-       initConfigTypeMap(
+        void initConfigTypeMap(
             const char* paramName,
             NPKeyValueParameter * pVariable,
             const char* defaultDesc
-       );
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               EventTrigger * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            EventTrigger * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               std::vector<EventTrigger> * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            std::vector<EventTrigger> * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               EventTriggerNode * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            EventTriggerNode * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               std::vector<EventTriggerNode> * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            std::vector<EventTriggerNode> * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               EventTriggerCoordinator * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            EventTriggerCoordinator * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
-       void
-           initConfigTypeMap(
-               const char* paramName,
-               std::vector<EventTriggerCoordinator> * pVariable,
-               const char* defaultDesc,
-               const char* condition_key = nullptr,
-               const char* condition_value = nullptr
-           );
+        void initConfigTypeMap(
+            const char* paramName,
+            std::vector<EventTriggerCoordinator> * pVariable,
+            const char* defaultDesc,
+            const char* condition_key = nullptr,
+            const char* condition_value = nullptr
+        );
 
        template< typename T >
         void EnforceParameterRange( const std::string& key, T value, json::QuickInterpreter& jsonObj )
@@ -671,10 +656,10 @@ namespace Kernel
 
             if( ignoreParameter( pJson, condition_key, condition_value ) )
             {
-                return true;
+                return true; // param is missing and that's ok.
             }
 
-            if (pJson && pJson->Exist(key) == false )
+            if (pJson && pJson->Exist(key) == false)
             {
                 if( _useDefaults )
                 {
@@ -796,7 +781,13 @@ namespace Kernel
                     }
                     else
                     {
-                        throw Kernel::GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, (std::string("Failed to find enum match for value ") + enum_value_string + " and key " + key).c_str() );
+                        std::ostringstream errorMsgFullList;
+                        errorMsgFullList << "Failed to find enum match for value "
+                                         << lower
+                                         << " and key "
+                                         << key
+                                         << ".";
+                        throw Kernel::GeneralConfigurationException( __FILE__, __LINE__, __FUNCTION__, errorMsgFullList.str().c_str() );
                     }
                 }
             }
@@ -852,12 +843,11 @@ namespace Kernel
         public:
             InterventionConfig();
             InterventionConfig(json::QuickInterpreter* qi);
+
             virtual json::QuickBuilder GetSchema() override;
             virtual void ConfigureFromJsonAndKey( const Configuration* inputJson, const std::string& key ) override;
             virtual bool  HasValidDefault() const override { return false; }
             json::Element _json;
-            //json::QuickInterpreter _qi;
-
             static void serialize(IArchive&, InterventionConfig&);
     };
 

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -168,6 +168,7 @@ namespace Kernel
         typedef std::map< std::string, std::vector< std::vector< std::vector< std::string > > > * > tVector3dStringConfigTypeMapType;
         typedef std::map< std::string, const std::set< std::string > * > tVectorStringConstraintsTypeMapType;
         typedef std::map< std::string, std::vector< float > * > tVectorFloatConfigTypeMapType;
+        typedef std::map< std::string, std::vector< bool > * > tVectorBoolConfigTypeMapType;
         typedef std::map< std::string, std::vector< int > * > tVectorIntConfigTypeMapType;
         typedef std::map< std::string, std::vector< uint32_t > * >tVectorUint32ConfigTypeMapType;
         typedef std::map< std::string, std::vector< std::vector< float > > * > tVector2dFloatConfigTypeMapType;
@@ -176,6 +177,7 @@ namespace Kernel
         typedef std::map< std::string, tFloatFloatMapConfigType * > tFloatFloatMapConfigTypeMapType;
         typedef std::map< std::string, tStringFloatMapConfigType * > tStringFloatMapConfigTypeMapType;
         typedef std::map< std::string, RangedFloat * > tRangedFloatConfigTypeMapType;
+        typedef std::map< std::string, NonNegativeFloat * > tNonNegativeFloatConfigTypeMapType;
         typedef std::map< std::string, NaturalNumber * > tNNConfigTypeMapType;
         typedef std::map< std::string, JsonConfigurable * > tJsonConfigurableMapType;
         typedef std::map< std::string, IComplexJsonConfigurable * > tComplexJsonConfigurableMapType;
@@ -239,6 +241,7 @@ namespace Kernel
             tVectorStringConstraintsTypeMapType vector2dStringConstraintsTypeMap;
             tVectorStringConstraintsTypeMapType vector3dStringConstraintsTypeMap;
             tVectorFloatConfigTypeMapType vectorFloatConfigTypeMap;
+            tVectorBoolConfigTypeMapType vectorBoolConfigTypeMap;
             tVectorIntConfigTypeMapType vectorIntConfigTypeMap;
             tVectorUint32ConfigTypeMapType vectorUint32ConfigTypeMap;
             tVector2dFloatConfigTypeMapType vector2dFloatConfigTypeMap;
@@ -247,6 +250,7 @@ namespace Kernel
             tFloatFloatMapConfigTypeMapType ffMapConfigTypeMap;
             tStringFloatMapConfigTypeMapType sfMapConfigTypeMap;
             tRangedFloatConfigTypeMapType rangedFloatConfigTypeMap;
+            tNonNegativeFloatConfigTypeMapType nonNegativeFloatConfigTypeMap;
             tNNConfigTypeMapType naturalNumberConfigTypeMap;
             tJsonConfigurableMapType jcTypeMap;
             tComplexJsonConfigurableMapType complexTypeMap;
@@ -396,7 +400,14 @@ namespace Kernel
             const char* paramName,
             std::vector< float > * pVariable,
             const char* description = default_description,
-            float min=-FLT_MAX, float max=FLT_MAX, bool ascending=false,
+            float min = -FLT_MAX, float max = FLT_MAX, bool ascending = false,
+            const char* condition_key = nullptr, const char* condition_value = nullptr
+        );
+
+        void initConfigTypeMap(
+            const char* paramName,
+            std::vector< bool > * pVariable,
+            const char* description = default_description,
             const char* condition_key = nullptr, const char* condition_value = nullptr
         );
 
@@ -449,7 +460,7 @@ namespace Kernel
             const char* paramName,
             tFloatFloatMapConfigType * pVariable,
             const char* description,
-            const char* condition_key, const char* condition_value
+            const char* condition_key = nullptr, const char* condition_value = nullptr
         );
 
         void initConfigTypeMap(
@@ -507,8 +518,7 @@ namespace Kernel
             const char* paramName,
             std::vector<IPKeyValueParameter>* pVariable,
             const char* description = default_description,
-            const char* condition_key = nullptr,
-            const char* condition_value = nullptr
+            const char* condition_key = nullptr, const char* condition_value = nullptr
         );
 
         void initConfigTypeMap(

--- a/utils/Configure.h
+++ b/utils/Configure.h
@@ -157,6 +157,7 @@ namespace Kernel
         typedef std::map< std::string, bool * > tBoolConfigTypeMapType;
         typedef std::map< std::string, int * > tIntConfigTypeMapType;
         typedef std::map< std::string, uint32_t * > tUint32ConfigTypeMapType;
+        typedef std::map< std::string, uint64_t * > tUint64ConfigTypeMapType;
         typedef std::map< std::string, float * > tFloatConfigTypeMapType;
         typedef std::map< std::string, double * > tDoubleConfigTypeMapType;
         typedef std::map< std::string, std::string * > tStringConfigTypeMapType;
@@ -224,6 +225,7 @@ namespace Kernel
             tBoolConfigTypeMapType boolConfigTypeMap;
             tIntConfigTypeMapType intConfigTypeMap;
             tUint32ConfigTypeMapType uint32ConfigTypeMap;
+            tUint64ConfigTypeMapType uint64ConfigTypeMap;
             tFloatConfigTypeMapType floatConfigTypeMap;
             tDoubleConfigTypeMapType doubleConfigTypeMap;
             tEnumConfigTypeMapType enumConfigTypeMap;
@@ -313,6 +315,14 @@ namespace Kernel
             uint32_t * pVariable,
             const char* description = default_description,
             uint32_t min = 0, uint32_t max = UINT_MAX, uint32_t defaultvalue = 0,
+            const char* condition_key = nullptr, const char* condition_value = nullptr
+        );
+
+        void initConfigTypeMap(
+            const char* paramName,
+            uint64_t * pVariable,
+            const char* description = default_description,
+            uint64_t min = 0, uint64_t max = UINT_MAX, uint64_t defaultvalue = 0,
             const char* condition_key = nullptr, const char* condition_value = nullptr
         );
 

--- a/utils/FactorySupport.h
+++ b/utils/FactorySupport.h
@@ -30,8 +30,6 @@ namespace Kernel
     typedef std::function<ISupports* (void)> instantiator_function_t;
     typedef map<string, instantiator_function_t> support_spec_map_t;
 
-    static const char hexval[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-
     template <class ReturnTypeT>
     ReturnTypeT* CreateInstanceFromSpecs(const Configuration* config, support_spec_map_t &specs, bool query_for_return_interface = true)
     {
@@ -59,10 +57,7 @@ namespace Kernel
         if (specs.end() == it)
         {
             std::ostringstream errMsg;
-            errMsg << "Could not instantiate unknown class '"
-                   << classname
-                   << "'."
-                   << std::endl;
+            errMsg << "Could not instantiate unknown class '" << classname << "'." << std::endl;
             throw FactoryCreateFromJsonException( __FILE__, __LINE__, __FUNCTION__, errMsg.str().c_str() );
         } 
         else
@@ -79,22 +74,6 @@ namespace Kernel
                 string templateClassName = typeid( ReturnTypeT ).name();
                 templateClassName = templateClassName.substr( templateClassName.find_last_of( "::" ) + 1 );
 
-                // debug logging
-                //char iidStr[17];
-                //_snprintf( iidStr, 17, "%x", (char*)(TypeInfo<ReturnTypeT>::GetIID((char*)templateClassName.c_str()).data) );
-#ifdef _IID_DEBUG
-                const char * hval = (const char*)TypeInfo<ReturnTypeT>::GetIID( (char*)templateClassName.c_str() ).data;
-                char finalhash[32];
-                memset( finalhash, '\0', 32 );
-
-                for( int j = 0; j < 10; j++ )
-                {
-                    finalhash[j * 2] = hexval[( ( hval[j] >> 4 ) & 0xF )];
-                    finalhash[( j * 2 ) + 1] = hexval[( hval[j] ) & 0x0F];
-                }
-
-                std::cerr << "[DEBUG] classname = " << typeid( ReturnTypeT ).name() << ", iid = " << finalhash << std::endl;
-#endif 
                 if( s_OK != obj->QueryInterface( TypeInfo<ReturnTypeT>::GetIID( (char*)templateClassName.c_str() ), (void**)&ri ) )
                 {
                     /* Didn't even support what we wanted, dispose of it and return null */
@@ -123,9 +102,8 @@ namespace Kernel
             if( conf_obj ) conf_obj->Release();  // release reference as 'conf_obj' is going out of scope.
         }
 
-
         // returning a plain object pointer type, force casted
-        return (ReturnTypeT*)obj; // obj should have a reference count of 1
+        return static_cast<ReturnTypeT*>(obj); // obj should have a reference count of 1
     }
 
 #define DECLARE_FACTORY_REGISTERED(factoryname, classname, via_interface) \

--- a/utils/ISupports.h
+++ b/utils/ISupports.h
@@ -11,6 +11,8 @@
 
 namespace Kernel
 {
+    struct IConfigurable;
+
     /* This file contains the basic definitions needed for a simplified COM-like ISupports/IUnknown model for implementing dynamic interface querying.
         Reference counting is not supported yet and wont be unless our ownership model becomes more complex. 
     */
@@ -52,6 +54,8 @@ namespace Kernel
         // TODO: not implementing these because we have a simple hierarchical ownership structure...for the time being, but should be done soon <ERAD-285>
         virtual int32_t AddRef() = 0; // these return signed values because subtle concurrency issues could result in negative refcounts being returned in theory
         virtual int32_t Release() = 0;
+
+        virtual IConfigurable* GetConfigurable() { return nullptr; }
 
         virtual ~ISupports() {}
     };


### PR DESCRIPTION
Changes to functionality in EMOD (not currently used)
- Supports parameter dependencies on a Boolean being False (e.g., requires "Enable_The_Thing": 0)
- Supports a list of parameter dependencies (multiple dependencies AND'd together).

Additional functionality in EMOD (not currently used):
- Adds initConfig for int64_t
- Adds initConfig for vector of bool
- Add MatchesDependency function for dependency checking outside of the Configure.cpp file