### PR TITLE
QueryInterface Removal Trial

### DIFF
--- a/Eradication/AdditionalRestrictions.cpp
+++ b/Eradication/AdditionalRestrictions.cpp
@@ -95,8 +95,6 @@ namespace Kernel
         release_assert(false);
     }
 
-
-
     BEGIN_QUERY_INTERFACE_BODY(IsPregnant)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsPregnant)

--- a/Eradication/AdditionalRestrictions.cpp
+++ b/Eradication/AdditionalRestrictions.cpp
@@ -8,7 +8,6 @@
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(HasIntervention)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasIntervention)
 
@@ -54,7 +53,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(HasIP)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasIP)
 
@@ -100,7 +98,6 @@ namespace Kernel
 
 
     BEGIN_QUERY_INTERFACE_BODY(IsPregnant)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsPregnant)
 

--- a/Eradication/AdditionalRestrictionsAbstract.h
+++ b/Eradication/AdditionalRestrictionsAbstract.h
@@ -17,6 +17,8 @@ namespace Kernel
         AdditionalRestrictionsAbstract();
         virtual bool Configure(const Configuration* config) override;
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
     protected:
         bool m_CompareTo;
     };

--- a/Eradication/AdditionalRestrictionsHIV.cpp
+++ b/Eradication/AdditionalRestrictionsHIV.cpp
@@ -9,7 +9,6 @@
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(IsHivPositive)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsHivPositive)
 
@@ -75,7 +74,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(IsOnART)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsOnART)
 
@@ -99,7 +97,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(HasBeenOnArtMoreOrLessThanNumMonths)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasBeenOnArtMoreOrLessThanNumMonths)
 
@@ -147,7 +144,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(HasCd4BetweenMinAndMax)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasCd4BetweenMinAndMax)
 

--- a/Eradication/AdditionalRestrictionsSTI.cpp
+++ b/Eradication/AdditionalRestrictionsSTI.cpp
@@ -10,7 +10,6 @@
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(IsCircumcised)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsCircumcised)
 
@@ -34,7 +33,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(IsPostDebut)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(IsPostDebut)
 
@@ -58,7 +56,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(HasMoreOrLessThanNumPartners)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasMoreOrLessThanNumPartners)
 
@@ -125,7 +122,6 @@ namespace Kernel
     }
 
     BEGIN_QUERY_INTERFACE_BODY(HasHadMultiplePartnersInLastNumMonths)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasHadMultiplePartnersInLastNumMonths)
 

--- a/Eradication/BroadcastCoordinatorEvent.cpp
+++ b/Eradication/BroadcastCoordinatorEvent.cpp
@@ -5,9 +5,7 @@
 #endif
 
 #include "BroadcastCoordinatorEvent.h"
-#include "InterventionFactory.h"
 #include "Log.h"
-#include "EventTriggerCoordinator.h"
 #include "NodeEventContext.h"
 #include "SimulationEventContext.h"
 
@@ -16,7 +14,8 @@ SETUP_LOGGING( "BroadcastCoordinatorEvent" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED( BroadcastCoordinatorEvent )
-    IMPL_QUERY_INTERFACE2( BroadcastCoordinatorEvent, IEventCoordinator, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(BroadcastCoordinatorEvent)
+    END_QUERY_INTERFACE_BODY(BroadcastCoordinatorEvent)
 
     BroadcastCoordinatorEvent::BroadcastCoordinatorEvent()
         : JsonConfigurable()

--- a/Eradication/BroadcastCoordinatorEvent.h
+++ b/Eradication/BroadcastCoordinatorEvent.h
@@ -20,6 +20,8 @@ namespace Kernel
         virtual bool Configure( const Configuration * inputJson ) override;
         virtual QuickBuilder GetSchema() override;
 
+        virtual IConfigurable*  GetConfigurable()  override { return JsonConfigurable::GetConfigurable(); }
+
         // IEventCoordinator methods
         virtual void SetContextTo( ISimulationEventContext *isec ) override;
         virtual void CheckStartDay( float campaignStartDay ) const override { };

--- a/Eradication/CalendarEventCoordinator.cpp
+++ b/Eradication/CalendarEventCoordinator.cpp
@@ -11,8 +11,8 @@ SETUP_LOGGING( "CalendarEventCoordinator" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(CalendarEventCoordinator)
-
-    IMPL_QUERY_INTERFACE2(CalendarEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(CalendarEventCoordinator)
+    END_QUERY_INTERFACE_BODY(CalendarEventCoordinator)
 
     CalendarEventCoordinator::CalendarEventCoordinator()
     : StandardInterventionDistributionEventCoordinator(false)//false=don't use standard demographic coverage

--- a/Eradication/CampaignEvent.cpp
+++ b/Eradication/CampaignEvent.cpp
@@ -28,7 +28,7 @@ namespace Kernel
     template CampaignEventFactory* ObjectFactory<CampaignEvent, CampaignEventFactory>::getInstance();
 
     CampaignEventFactory::CampaignEventFactory()
-        : ObjectFactory<CampaignEvent, CampaignEventFactory>( false ) // do not queryForReturnInterface
+        : ObjectFactory<CampaignEvent, CampaignEventFactory>()
     {
     }
 

--- a/Eradication/CampaignEvent.cpp
+++ b/Eradication/CampaignEvent.cpp
@@ -11,7 +11,6 @@
 #include "Log.h"
 #include "Configuration.h"
 #include "Configure.h"
-#include "ConfigurationImpl.h"
 #include "CampaignEvent.h"
 #include "EventCoordinator.h"
 #include "FactorySupport.h"
@@ -75,8 +74,8 @@ namespace Kernel
     // CampaignEvent
 
     IMPLEMENT_FACTORY_REGISTERED(CampaignEvent)
-
-    IMPL_QUERY_INTERFACE1(CampaignEvent, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(CampaignEvent)
+    END_QUERY_INTERFACE_BODY(CampaignEvent)
 
     CampaignEvent::CampaignEvent()
         : start_day(0.0f)

--- a/Eradication/CampaignEventByYear.cpp
+++ b/Eradication/CampaignEventByYear.cpp
@@ -14,8 +14,9 @@ namespace Kernel
     //
     // CampaignEventByYear class here.
     //
-    IMPL_QUERY_INTERFACE1(CampaignEventByYear, IConfigurable)
     IMPLEMENT_FACTORY_REGISTERED(CampaignEventByYear)
+    BEGIN_QUERY_INTERFACE_BODY(CampaignEventByYear)
+    END_QUERY_INTERFACE_BODY(CampaignEventByYear)
 
     CampaignEventByYear::CampaignEventByYear()
     {

--- a/Eradication/CommunityHealthWorkerEventCoordinator.cpp
+++ b/Eradication/CommunityHealthWorkerEventCoordinator.cpp
@@ -24,7 +24,8 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED(CommunityHealthWorkerEventCoordinator)
-    IMPL_QUERY_INTERFACE2(CommunityHealthWorkerEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(CommunityHealthWorkerEventCoordinator)
+    END_QUERY_INTERFACE_BODY(CommunityHealthWorkerEventCoordinator)
 
     CommunityHealthWorkerEventCoordinator::CommunityHealthWorkerEventCoordinator()
     : m_Parent( nullptr )

--- a/Eradication/CommunityHealthWorkerEventCoordinator.h
+++ b/Eradication/CommunityHealthWorkerEventCoordinator.h
@@ -48,6 +48,8 @@ namespace Kernel
         virtual bool Configure( const Configuration * inputJson ) override;
         virtual QuickBuilder GetSchema() override;
 
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
+
         // IEventCoordinator methods
         virtual void SetContextTo( ISimulationEventContext *isec ) override;
         virtual void CheckStartDay( float campaignStartDay ) const override {};

--- a/Eradication/CoverageByNodeEventCoordinator.cpp
+++ b/Eradication/CoverageByNodeEventCoordinator.cpp
@@ -85,8 +85,8 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED(CoverageByNodeEventCoordinator)
-
-    IMPL_QUERY_INTERFACE2(CoverageByNodeEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(CoverageByNodeEventCoordinator)
+    END_QUERY_INTERFACE_BODY(CoverageByNodeEventCoordinator)
 
     CoverageByNodeEventCoordinator::CoverageByNodeEventCoordinator()
         : StandardInterventionDistributionEventCoordinator( false )//false=don't use standard demographic coverage

--- a/Eradication/DelayEventCoordinator.cpp
+++ b/Eradication/DelayEventCoordinator.cpp
@@ -8,7 +8,8 @@ SETUP_LOGGING( "DelayEventCoordinator" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED( DelayEventCoordinator )
-    IMPL_QUERY_INTERFACE2( DelayEventCoordinator, IEventCoordinator, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(DelayEventCoordinator)
+    END_QUERY_INTERFACE_BODY(DelayEventCoordinator)
 
     DelayEventCoordinator::DelayEventCoordinator()
         : TriggeredEventCoordinator()

--- a/Eradication/FirstNodeWithNodePropertyEventCoordinator.cpp
+++ b/Eradication/FirstNodeWithNodePropertyEventCoordinator.cpp
@@ -121,7 +121,8 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED( FirstNodeWithNodePropertyEventCoordinator )
-    IMPL_QUERY_INTERFACE2( FirstNodeWithNodePropertyEventCoordinator, IEventCoordinator, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(FirstNodeWithNodePropertyEventCoordinator)
+    END_QUERY_INTERFACE_BODY(FirstNodeWithNodePropertyEventCoordinator)
 
     FirstNodeWithNodePropertyEventCoordinator::FirstNodeWithNodePropertyEventCoordinator()
         : TriggeredEventCoordinator()

--- a/Eradication/HasRelationship.cpp
+++ b/Eradication/HasRelationship.cpp
@@ -17,7 +17,6 @@ static constexpr float DAYSPERMONTH = (DAYSPERYEAR / MONTHSPERYEAR);
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(HasRelationship)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(HasRelationship)
 

--- a/Eradication/IncidenceEventCoordinator.cpp
+++ b/Eradication/IncidenceEventCoordinator.cpp
@@ -463,7 +463,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED( IncidenceEventCoordinator )
 
     BEGIN_QUERY_INTERFACE_BODY( IncidenceEventCoordinator )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IEventCoordinator )
         HANDLE_ISUPPORTS_VIA( IEventCoordinator )
     END_QUERY_INTERFACE_BODY( IncidenceEventCoordinator )

--- a/Eradication/IncidenceEventCoordinator.h
+++ b/Eradication/IncidenceEventCoordinator.h
@@ -180,6 +180,8 @@ namespace Kernel
         virtual bool Configure( const Configuration * inputJson ) override;
         virtual QuickBuilder GetSchema() override;
 
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
+
         // IEventCoordinator methods
         virtual void SetContextTo( ISimulationEventContext *isec ) override;
         virtual void CheckStartDay( float campaignStartDay ) const override { };

--- a/Eradication/NChooserEventCoordinator.cpp
+++ b/Eradication/NChooserEventCoordinator.cpp
@@ -729,7 +729,8 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED(NChooserEventCoordinator)
-    IMPL_QUERY_INTERFACE2(NChooserEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(NChooserEventCoordinator)
+    END_QUERY_INTERFACE_BODY(NChooserEventCoordinator)
 
     NChooserEventCoordinator::NChooserEventCoordinator()
     : m_Parent( nullptr )

--- a/Eradication/NChooserEventCoordinator.h
+++ b/Eradication/NChooserEventCoordinator.h
@@ -244,6 +244,8 @@ namespace Kernel
 
         virtual bool Configure( const Configuration * inputJson ) override;
 
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
+
         // IEventCoordinator methods
         virtual void SetContextTo(ISimulationEventContext *isec) override;
         virtual void CheckStartDay( float campaignStartDay ) const override;

--- a/Eradication/NChooserEventCoordinatorHIV.cpp
+++ b/Eradication/NChooserEventCoordinatorHIV.cpp
@@ -34,10 +34,6 @@ namespace Kernel
     // --- TargetedDistributionHIV
     // ------------------------------------------------------------------------
 
-    BEGIN_QUERY_INTERFACE_DERIVED(TargetedDistributionHIV,TargetedDistributionSTI)
-    END_QUERY_INTERFACE_DERIVED(TargetedDistributionHIV,TargetedDistributionSTI)
-
-
     TargetedDistributionHIV::TargetedDistributionHIV( NChooserObjectFactory* pObjectFactory )
     : TargetedDistributionSTI(pObjectFactory)
     , m_Vector2dStringDiseaseStates()
@@ -225,7 +221,6 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED(NChooserEventCoordinatorHIV)
-    IMPL_QUERY_INTERFACE2(NChooserEventCoordinatorHIV, IEventCoordinator, IConfigurable)
 
     NChooserEventCoordinatorHIV::NChooserEventCoordinatorHIV()
     : NChooserEventCoordinatorSTI( new NChooserObjectFactoryHIV() )

--- a/Eradication/NChooserEventCoordinatorHIV.h
+++ b/Eradication/NChooserEventCoordinatorHIV.h
@@ -7,7 +7,6 @@
 namespace Kernel
 {
     class TargetedDistributionHIV;
-    //struct IIndividualHumanEventContext;
     struct IIndividualHumanSTI;
     struct IIndividualHumanHIV;
     struct IHIVMedicalHistory;
@@ -47,8 +46,6 @@ namespace Kernel
     class IDMAPI TargetedDistributionHIV : public TargetedDistributionSTI
     {
     public:
-        DECLARE_QUERY_INTERFACE()
-
         TargetedDistributionHIV( NChooserObjectFactory* pObjectFactory );
         virtual ~TargetedDistributionHIV();
 
@@ -96,8 +93,6 @@ namespace Kernel
     {
         DECLARE_FACTORY_REGISTERED_EXPORT(EventCoordinatorFactory, NChooserEventCoordinatorHIV, IEventCoordinator)    
     public:
-        DECLARE_QUERY_INTERFACE()
-
         NChooserEventCoordinatorHIV();
         NChooserEventCoordinatorHIV( NChooserObjectFactory* pObjectFactory );
         virtual ~NChooserEventCoordinatorHIV();

--- a/Eradication/NChooserEventCoordinatorSTI.cpp
+++ b/Eradication/NChooserEventCoordinatorSTI.cpp
@@ -17,7 +17,6 @@ namespace Kernel
     BEGIN_QUERY_INTERFACE_DERIVED(TargetedDistributionSTI,TargetedDistribution)
     END_QUERY_INTERFACE_DERIVED(TargetedDistributionSTI,TargetedDistribution)
 
-
     TargetedDistributionSTI::TargetedDistributionSTI( NChooserObjectFactory* pObjectFactory )
     : TargetedDistribution( pObjectFactory )
     , m_StartYear(1900.0)
@@ -118,7 +117,6 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     IMPLEMENT_FACTORY_REGISTERED(NChooserEventCoordinatorSTI)
-    IMPL_QUERY_INTERFACE2(NChooserEventCoordinatorSTI, IEventCoordinator, IConfigurable)
 
     NChooserEventCoordinatorSTI::NChooserEventCoordinatorSTI()
     : NChooserEventCoordinator( new NChooserObjectFactorySTI() )

--- a/Eradication/NChooserEventCoordinatorSTI.h
+++ b/Eradication/NChooserEventCoordinatorSTI.h
@@ -57,8 +57,6 @@ namespace Kernel
     {
         DECLARE_FACTORY_REGISTERED_EXPORT(EventCoordinatorFactory, NChooserEventCoordinatorSTI, IEventCoordinator)    
     public:
-        DECLARE_QUERY_INTERFACE()
-
         NChooserEventCoordinatorSTI();
         NChooserEventCoordinatorSTI( NChooserObjectFactory* pObjectFactory );
         virtual ~NChooserEventCoordinatorSTI();

--- a/Eradication/NodeSTI.cpp
+++ b/Eradication/NodeSTI.cpp
@@ -25,7 +25,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED(NodeSTI, Node)
         HANDLE_INTERFACE(INodeSTI)
-        HANDLE_INTERFACE(IConfigurable)
     END_QUERY_INTERFACE_DERIVED(NodeSTI, Node)
 
     bool NodeSTI::Configure( const Configuration* config )

--- a/Eradication/ReferenceTrackingEventCoordinator.cpp
+++ b/Eradication/ReferenceTrackingEventCoordinator.cpp
@@ -12,7 +12,8 @@ SETUP_LOGGING( "ReferenceTrackingEventCoordinator" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(ReferenceTrackingEventCoordinator)
-    IMPL_QUERY_INTERFACE2(ReferenceTrackingEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinator)
+    END_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinator)
 
     ReferenceTrackingEventCoordinator::ReferenceTrackingEventCoordinator()
         : StandardInterventionDistributionEventCoordinator( false )//false=don't use standard demographic coverage

--- a/Eradication/ReferenceTrackingEventCoordinatorHIV.cpp
+++ b/Eradication/ReferenceTrackingEventCoordinatorHIV.cpp
@@ -10,7 +10,8 @@ SETUP_LOGGING( "ReferenceTrackingEventCoordinatorHIV" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(ReferenceTrackingEventCoordinatorHIV)
-    IMPL_QUERY_INTERFACE2(ReferenceTrackingEventCoordinatorHIV, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinatorHIV)
+    END_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinatorHIV)
 
     ReferenceTrackingEventCoordinatorHIV::ReferenceTrackingEventCoordinatorHIV()
     : ReferenceTrackingEventCoordinator()

--- a/Eradication/ReferenceTrackingEventCoordinatorTrackingConfig.cpp
+++ b/Eradication/ReferenceTrackingEventCoordinatorTrackingConfig.cpp
@@ -15,7 +15,8 @@ SETUP_LOGGING( "ReferenceTrackingEventCoordinatorTrackingConfig" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(ReferenceTrackingEventCoordinatorTrackingConfig)
-    IMPL_QUERY_INTERFACE2(ReferenceTrackingEventCoordinatorTrackingConfig, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinatorTrackingConfig)
+    END_QUERY_INTERFACE_BODY(ReferenceTrackingEventCoordinatorTrackingConfig)
 
     ReferenceTrackingEventCoordinatorTrackingConfig::ReferenceTrackingEventCoordinatorTrackingConfig()
         : StandardInterventionDistributionEventCoordinator( false )//false=don't use standard demographic coverage

--- a/Eradication/SimulationConfig.cpp
+++ b/Eradication/SimulationConfig.cpp
@@ -74,7 +74,6 @@ support_spec_map_t& SimulationConfigFactory::getRegisteredClasses()
 IMPLEMENT_FACTORY_REGISTERED(SimulationConfig)
 
 BEGIN_QUERY_INTERFACE_BODY(SimulationConfig)
-     HANDLE_INTERFACE(IConfigurable)
 END_QUERY_INTERFACE_BODY(SimulationConfig)
 
 SimulationConfig::~SimulationConfig()

--- a/Eradication/SpatialReportMalaria.cpp
+++ b/Eradication/SpatialReportMalaria.cpp
@@ -24,7 +24,6 @@ GET_SCHEMA_STATIC_WRAPPER_IMPL(SpatialReportMalaria,SpatialReportMalaria)
 
 BEGIN_QUERY_INTERFACE_BODY( SpatialReportMalaria )
     HANDLE_INTERFACE( IReportMalariaDiagnostics )
-    HANDLE_INTERFACE( IConfigurable )
     HANDLE_INTERFACE( IReport )
     HANDLE_ISUPPORTS_VIA( IReport )
 END_QUERY_INTERFACE_BODY( SpatialReportMalaria )

--- a/Eradication/StandardEventCoordinator.cpp
+++ b/Eradication/StandardEventCoordinator.cpp
@@ -7,7 +7,6 @@
 #include "Environment.h"
 #include "StandardEventCoordinator.h"
 #include "Configuration.h"
-#include "ConfigurationImpl.h"
 #include "FactorySupport.h"
 #include "InterventionFactory.h"
 #include "IIndividualHuman.h"
@@ -30,8 +29,8 @@ namespace Kernel
 {
 
     IMPLEMENT_FACTORY_REGISTERED(StandardInterventionDistributionEventCoordinator)
-
-    IMPL_QUERY_INTERFACE2(StandardInterventionDistributionEventCoordinator, IEventCoordinator, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(StandardInterventionDistributionEventCoordinator)
+    END_QUERY_INTERFACE_BODY(StandardInterventionDistributionEventCoordinator)
 
     // ctor
     StandardInterventionDistributionEventCoordinator::StandardInterventionDistributionEventCoordinator( bool useDemographicCoverage ) 
@@ -40,8 +39,6 @@ namespace Kernel
     , num_repetitions(1)
     , tsteps_between_reps(-1)
     , tsteps_since_last(0)
-    //, include_emigrants(false)
-    //, include_immigrants(false)
     , intervention_activated(false)
     , cached_nodes()
     , node_suids()
@@ -77,9 +74,6 @@ namespace Kernel
         {
             InitializeIndividualSelectionType( inputJson );
         }
-
-        //initConfigTypeMap("Include_Departures", &include_emigrants, Include_Departures_DESC_TEXT, false );
-        //initConfigTypeMap("Include_Arrivals", &include_immigrants, Include_Arrivals_DESC_TEXT, false );
 
         demographic_restrictions.ConfigureRestrictions( this, inputJson );
 
@@ -216,20 +210,6 @@ namespace Kernel
         // Store uids and node (event context) pointers
         node_suids.push_back(node_suid);
         cached_nodes.push_back(parent->GetNodeEventContext(node_suid));
-
-#if 0
-        INodeEventContext * pNec = parent->GetNodeEventContext(node_suid);
-        // Register unconditionally to be notified when individuals arrive at our node so we can zap them!
-        // TODO: Make this param driven
-        if( include_immigrants )
-        {
-            pNec->RegisterTravelDistributionSource( this, INodeEventContext::Arrival );
-        }
-        if( include_emigrants )
-        {
-            pNec->RegisterTravelDistributionSource( this, INodeEventContext::Departure );
-        }
-#endif
     }
 
     void StandardInterventionDistributionEventCoordinator::Update( float dt )

--- a/Eradication/StandardEventCoordinator.h
+++ b/Eradication/StandardEventCoordinator.h
@@ -31,6 +31,8 @@ namespace Kernel
         StandardInterventionDistributionEventCoordinator( bool useDemographicCoverage = true );
         virtual ~StandardInterventionDistributionEventCoordinator();
 
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
+
         // IEventCoordinator
         virtual void SetContextTo(ISimulationEventContext *isec);
         virtual void CheckStartDay( float campaignStartDay ) const override {};

--- a/Eradication/TargetingLogic.cpp
+++ b/Eradication/TargetingLogic.cpp
@@ -118,7 +118,6 @@ namespace Kernel
     // ------------------------------------------------------------------------
 
     BEGIN_QUERY_INTERFACE_BODY(TargetingLogic)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IAdditionalRestrictions)
     END_QUERY_INTERFACE_BODY(TargetingLogic)
 

--- a/Eradication/TargetingLogic.h
+++ b/Eradication/TargetingLogic.h
@@ -41,6 +41,8 @@ namespace Kernel
         TargetingLogic();
         virtual ~TargetingLogic();
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
         virtual bool Configure(const Configuration* config) override;
         virtual bool IsQualified(IIndividualHumanEventContext* pContext) const override;
 

--- a/Eradication/TriggeredEventCoordinator.cpp
+++ b/Eradication/TriggeredEventCoordinator.cpp
@@ -1,7 +1,6 @@
 
 #include "stdafx.h"
 #include "TriggeredEventCoordinator.h"
-#include "InterventionFactory.h"
 #include "SimulationEventContext.h"
 
 SETUP_LOGGING( "TriggeredEventCoordinator" )
@@ -9,7 +8,8 @@ SETUP_LOGGING( "TriggeredEventCoordinator" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED( TriggeredEventCoordinator )
-    IMPL_QUERY_INTERFACE2( TriggeredEventCoordinator, IEventCoordinator, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(TriggeredEventCoordinator)
+    END_QUERY_INTERFACE_BODY(TriggeredEventCoordinator)
 
     TriggeredEventCoordinator::TriggeredEventCoordinator()
         : StandardInterventionDistributionEventCoordinator( true )

--- a/Eradication/VectorSurveillanceEventCoordinator.cpp
+++ b/Eradication/VectorSurveillanceEventCoordinator.cpp
@@ -25,7 +25,8 @@ namespace Kernel
     // --- VectorCounter
     // ------------------------------------------------------------------------
 
-    IMPL_QUERY_INTERFACE1( VectorCounter, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(VectorCounter)
+    END_QUERY_INTERFACE_BODY(VectorCounter)
 
     VectorCounter::VectorCounter()
         : JsonConfigurable()
@@ -488,7 +489,8 @@ namespace Kernel
     // --- VectorResponder
     // ------------------------------------------------------------------------
 
-    IMPL_QUERY_INTERFACE1( VectorResponder, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(VectorResponder)
+    END_QUERY_INTERFACE_BODY(VectorResponder)
 
 #define PYTHON_FUNC_NAME_CREATE  "create_responder"
 #define PYTHON_FUNC_NAME_DELETE  "delete_responder"
@@ -671,7 +673,6 @@ namespace Kernel
     BEGIN_QUERY_INTERFACE_BODY( VectorSurveillanceEventCoordinator )
         HANDLE_INTERFACE( IEventCoordinatorEventContext )
         HANDLE_INTERFACE( ICoordinatorEventObserver )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IEventCoordinator )
         HANDLE_ISUPPORTS_VIA( IEventCoordinator )
     END_QUERY_INTERFACE_BODY( VectorSurveillanceEventCoordinator )

--- a/Eradication/VectorSurveillanceEventCoordinator.h
+++ b/Eradication/VectorSurveillanceEventCoordinator.h
@@ -179,6 +179,8 @@ namespace Kernel
         // other
         ISimulationEventContext* GetSimulationContext() { return m_Parent; };
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
     protected:
 
         void Register();

--- a/campaign/Interventions.h
+++ b/campaign/Interventions.h
@@ -115,6 +115,8 @@ namespace Kernel
         // IReportInterventionData
         virtual ReportInterventionData GetReportInterventionData() const override;
 
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
+
     protected:
         BaseIntervention();
         BaseIntervention( const BaseIntervention& );
@@ -148,6 +150,8 @@ namespace Kernel
         virtual bool Expired() override;
         virtual void SetExpired( bool isExpired ) override;
         virtual void SetContextTo( INodeEventContext *context ) override;
+
+        virtual IConfigurable* GetConfigurable() override { return JsonConfigurable::GetConfigurable(); }
 
         // IReportInterventionData
         virtual ReportInterventionData GetReportInterventionData() const override;

--- a/campaign/NodeSet.h
+++ b/campaign/NodeSet.h
@@ -39,6 +39,8 @@ namespace Kernel
         virtual bool Contains(INodeEventContext *ndc);
         virtual std::vector<ExternalNodeId_t> IsSubset(const std::vector<ExternalNodeId_t>& demographic_node_ids);
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
     protected:
         DECLARE_SERIALIZABLE(NodeSetAll);
     };
@@ -55,6 +57,8 @@ namespace Kernel
 
         virtual bool Contains(INodeEventContext *ndc);
         virtual std::vector<ExternalNodeId_t> IsSubset(const std::vector<ExternalNodeId_t>& demographic_node_ids);
+
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
 
     protected:
         std::vector<ExternalNodeId_t> nodelist;

--- a/campaign/NodeSetAll.cpp
+++ b/campaign/NodeSetAll.cpp
@@ -8,7 +8,8 @@ namespace Kernel
 {
     // NodeSetAll 
     IMPLEMENT_FACTORY_REGISTERED(NodeSetAll)
-    IMPL_QUERY_INTERFACE2(NodeSetAll, INodeSet, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(NodeSetAll)
+    END_QUERY_INTERFACE_BODY(NodeSetAll)
 
     bool NodeSetAll::Configure(const Configuration * pInputJson)
     {

--- a/campaign/NodeSetNodeList.cpp
+++ b/campaign/NodeSetNodeList.cpp
@@ -9,7 +9,8 @@ SETUP_LOGGING( "NodeSetNodeList" )
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(NodeSetNodeList)
-    IMPL_QUERY_INTERFACE2(NodeSetNodeList, INodeSet, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(NodeSetNodeList)
+    END_QUERY_INTERFACE_BODY(NodeSetNodeList)
 
     bool NodeSetNodeList::Configure(const Configuration* inputJson)
     {

--- a/interventions/ARTDropout.cpp
+++ b/interventions/ARTDropout.cpp
@@ -14,7 +14,6 @@ SETUP_LOGGING( "ARTDropout" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( ARTDropout )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )

--- a/interventions/AbstractDecision.cpp
+++ b/interventions/AbstractDecision.cpp
@@ -10,7 +10,6 @@ SETUP_LOGGING( "AbstractDecision" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( AbstractDecision )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )

--- a/interventions/AbstractSocietyOverrideIntervention.cpp
+++ b/interventions/AbstractSocietyOverrideIntervention.cpp
@@ -12,7 +12,6 @@ SETUP_LOGGING( "AbstractSocietyOverrideIntervention" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(AbstractSocietyOverrideIntervention)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(ISocietyOverrideIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)

--- a/interventions/AntiretroviralTherapy.cpp
+++ b/interventions/AntiretroviralTherapy.cpp
@@ -34,7 +34,6 @@ SETUP_LOGGING( "AntiretroviralTherapy" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( AntiretroviralTherapy )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )

--- a/interventions/Bednet.cpp
+++ b/interventions/Bednet.cpp
@@ -21,7 +21,6 @@ namespace Kernel
     BEGIN_QUERY_INTERFACE_BODY( AbstractBednet )
         HANDLE_INTERFACE( IAbstractBednet )
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )
     END_QUERY_INTERFACE_BODY( AbstractBednet )

--- a/interventions/BirthTriggeredIV.cpp
+++ b/interventions/BirthTriggeredIV.cpp
@@ -15,7 +15,6 @@ SETUP_LOGGING( "BirthTriggeredIV" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(BirthTriggeredIV)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IIndividualEventObserver)

--- a/interventions/BitingRisk.cpp
+++ b/interventions/BitingRisk.cpp
@@ -13,7 +13,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED( BitingRisk )
 
     BEGIN_QUERY_INTERFACE_BODY( BitingRisk )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )
     END_QUERY_INTERFACE_BODY( BitingRisk )

--- a/interventions/BroadcastCoordinatorEventFromNode.cpp
+++ b/interventions/BroadcastCoordinatorEventFromNode.cpp
@@ -52,7 +52,6 @@ namespace Kernel
 
 
     BEGIN_QUERY_INTERFACE_BODY(BroadcastCoordinatorEventFromNode)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/BroadcastEvent.cpp
+++ b/interventions/BroadcastEvent.cpp
@@ -11,7 +11,6 @@ SETUP_LOGGING( "BroadcastEvent" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(BroadcastEvent)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/BroadcastEventToOtherNodes.cpp
+++ b/interventions/BroadcastEventToOtherNodes.cpp
@@ -14,7 +14,6 @@ SETUP_LOGGING( "BroadcastEventToOtherNodes" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(BroadcastEventToOtherNodes)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/BroadcastNodeEvent.cpp
+++ b/interventions/BroadcastNodeEvent.cpp
@@ -10,7 +10,6 @@ SETUP_LOGGING( "BroadcastNodeEvent" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( BroadcastNodeEvent )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( INodeDistributableIntervention )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_ISUPPORTS_VIA( INodeDistributableIntervention )

--- a/interventions/CalendarIV.cpp
+++ b/interventions/CalendarIV.cpp
@@ -83,7 +83,6 @@ namespace Kernel
 
 
     BEGIN_QUERY_INTERFACE_BODY(IVCalendar)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IBaseIntervention)

--- a/interventions/CoitalActRiskFactors.cpp
+++ b/interventions/CoitalActRiskFactors.cpp
@@ -16,7 +16,6 @@ SETUP_LOGGING( "CoitalActRisk" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( CoitalActRiskFactors )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )
     END_QUERY_INTERFACE_BODY( CoitalActRiskFactors )

--- a/interventions/DelayedIntervention.cpp
+++ b/interventions/DelayedIntervention.cpp
@@ -15,7 +15,6 @@ SETUP_LOGGING( "DelayedIntervention" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(DelayedIntervention)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/Diagnostics.cpp
+++ b/interventions/Diagnostics.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "SimpleDiagnostic" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleDiagnostic)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/Drugs.cpp
+++ b/interventions/Drugs.cpp
@@ -11,7 +11,6 @@ SETUP_LOGGING( "GenericDrug" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(GenericDrug)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IDrug)
         HANDLE_INTERFACE(IBaseIntervention)

--- a/interventions/FemaleContraceptive.cpp
+++ b/interventions/FemaleContraceptive.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "FemaleContraceptive" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(FemaleContraceptive)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/HIVPiecewiseByYearAndSexDiagnostic.cpp
+++ b/interventions/HIVPiecewiseByYearAndSexDiagnostic.cpp
@@ -18,7 +18,6 @@ SETUP_LOGGING( "HIVPiecewiseByYearAndSexDiagnostic" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(HIVPiecewiseByYearAndSexDiagnostic)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/HIVRandomChoice.cpp
+++ b/interventions/HIVRandomChoice.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "HIVRandomChoice" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( HIVRandomChoice )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )

--- a/interventions/HIVSigmoidByYearAndSexDiagnostic.cpp
+++ b/interventions/HIVSigmoidByYearAndSexDiagnostic.cpp
@@ -14,7 +14,6 @@ SETUP_LOGGING( "HIVSigmoidByYearAndSexDiagnostic" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(HIVSigmoidByYearAndSexDiagnostic)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         //HANDLE_INTERFACE(IHealthSeekingBehavior)
         HANDLE_INTERFACE(IBaseIntervention)

--- a/interventions/HealthSeekingBehavior.cpp
+++ b/interventions/HealthSeekingBehavior.cpp
@@ -15,7 +15,6 @@ SETUP_LOGGING( "SimpleHealthSeekingBehavior" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleHealthSeekingBehavior)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/HousingModification.cpp
+++ b/interventions/HousingModification.cpp
@@ -15,7 +15,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleHousingModification)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(SimpleHousingModification)

--- a/interventions/HumanHostSeekingTrap.cpp
+++ b/interventions/HumanHostSeekingTrap.cpp
@@ -14,7 +14,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(HumanHostSeekingTrap)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(HumanHostSeekingTrap)

--- a/interventions/ImportPressure.cpp
+++ b/interventions/ImportPressure.cpp
@@ -12,7 +12,6 @@ SETUP_LOGGING( "ImportPressure" );
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(ImportPressure)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)
     END_QUERY_INTERFACE_BODY(ImportPressure)

--- a/interventions/IndividualImmunityChanger.cpp
+++ b/interventions/IndividualImmunityChanger.cpp
@@ -17,7 +17,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED(IndividualImmunityChanger)
 
     BEGIN_QUERY_INTERFACE_BODY(IndividualImmunityChanger)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IIndividualImmunityChanger)
         HANDLE_INTERFACE(IDistributableIntervention)

--- a/interventions/IndividualNonDiseaseDeathRateModifier.cpp
+++ b/interventions/IndividualNonDiseaseDeathRateModifier.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "IndividualNonDiseaseDeathRateModifier" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(IndividualNonDiseaseDeathRateModifier)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/IndividualRepellent.cpp
+++ b/interventions/IndividualRepellent.cpp
@@ -12,7 +12,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleIndividualRepellent)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(SimpleIndividualRepellent)

--- a/interventions/InputEIR.cpp
+++ b/interventions/InputEIR.cpp
@@ -13,7 +13,6 @@ namespace Kernel
     float ACTUALDAYSPERMONTH = float( DAYSPERYEAR ) / MONTHSPERYEAR;  // 30.416666
 
     BEGIN_QUERY_INTERFACE_BODY(InputEIR)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/InsecticideWaningEffect.cpp
+++ b/interventions/InsecticideWaningEffect.cpp
@@ -12,7 +12,8 @@ namespace Kernel
     // --- InsecticideWaningEffect
     // ------------------------------------------------------------------------
 
-    IMPL_QUERY_INTERFACE2(InsecticideWaningEffect, IInsecticideWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(InsecticideWaningEffect)
+    END_QUERY_INTERFACE_BODY(InsecticideWaningEffect)
 
     InsecticideWaningEffect::InsecticideWaningEffect()
         : InsecticideWaningEffect( false, false, false, false )
@@ -260,7 +261,8 @@ namespace Kernel
     // --- InsecticideWaningEffectCollection
     // ------------------------------------------------------------------------
 
-    IMPL_QUERY_INTERFACE2( InsecticideWaningEffectCollection, IInsecticideWaningEffect, IConfigurable )
+    BEGIN_QUERY_INTERFACE_BODY(InsecticideWaningEffectCollection)
+    END_QUERY_INTERFACE_BODY(InsecticideWaningEffectCollection)
 
         InsecticideWaningEffectCollection::InsecticideWaningEffectCollection()
         : InsecticideWaningEffectCollection( false, false, false, false )

--- a/interventions/InterventionForCurrentPartners.cpp
+++ b/interventions/InterventionForCurrentPartners.cpp
@@ -19,7 +19,6 @@ SETUP_LOGGING( "InterventionForCurrentPartners" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( InterventionForCurrentPartners )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )
     END_QUERY_INTERFACE_BODY( InterventionForCurrentPartners )

--- a/interventions/Ivermectin.cpp
+++ b/interventions/Ivermectin.cpp
@@ -14,7 +14,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(Ivermectin)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(Ivermectin)

--- a/interventions/MalariaChallenge.cpp
+++ b/interventions/MalariaChallenge.cpp
@@ -10,7 +10,6 @@ SETUP_LOGGING( "MalariaChallenge" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MalariaChallenge)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/MaleCircumcision.cpp
+++ b/interventions/MaleCircumcision.cpp
@@ -16,7 +16,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MaleCircumcision)
         HANDLE_INTERFACE( ICircumcision )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(MaleCircumcision)

--- a/interventions/MigrateFamily.cpp
+++ b/interventions/MigrateFamily.cpp
@@ -12,7 +12,6 @@ SETUP_LOGGING( "MigrateFamily" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MigrateFamily)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/MigrateIndividuals.cpp
+++ b/interventions/MigrateIndividuals.cpp
@@ -15,7 +15,6 @@ SETUP_LOGGING( "MigrateIndividuals" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MigrateIndividuals)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/ModifyStiCoInfectionStatus.cpp
+++ b/interventions/ModifyStiCoInfectionStatus.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "ModifyStiCoInfectionStatus" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(ModifyStiCoInfectionStatus)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(ModifyStiCoInfectionStatus)

--- a/interventions/MosquitoRelease.cpp
+++ b/interventions/MosquitoRelease.cpp
@@ -14,7 +14,6 @@ SETUP_LOGGING( "MosquitoRelease" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MosquitoRelease)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/MultiEffectVaccine.cpp
+++ b/interventions/MultiEffectVaccine.cpp
@@ -8,7 +8,6 @@ SETUP_LOGGING( "MultiEffectVaccine" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MultiEffectVaccine)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IVaccine)
         HANDLE_INTERFACE(IBaseIntervention)

--- a/interventions/MultiInterventionDistributor.cpp
+++ b/interventions/MultiInterventionDistributor.cpp
@@ -10,7 +10,6 @@ SETUP_LOGGING( "MultiInterventionDistributor" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(MultiInterventionDistributor)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/MultiNodeInterventionDistributor.cpp
+++ b/interventions/MultiNodeInterventionDistributor.cpp
@@ -9,7 +9,6 @@ SETUP_LOGGING( "MultiNodeInterventionDistributor" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( MultiNodeInterventionDistributor )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_INTERFACE( INodeDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( INodeDistributableIntervention )

--- a/interventions/NLHTIVNode.cpp
+++ b/interventions/NLHTIVNode.cpp
@@ -14,7 +14,6 @@ SETUP_LOGGING( "NLHTIVNode" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(NLHTIVNode)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(INodeEventObserver)

--- a/interventions/NodeLevelHealthTriggeredIV.cpp
+++ b/interventions/NodeLevelHealthTriggeredIV.cpp
@@ -17,7 +17,6 @@ SETUP_LOGGING( "NodeLevelHealthTriggeredIV" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(NodeLevelHealthTriggeredIV)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IIndividualEventObserver)

--- a/interventions/NodePropertyValueChanger.cpp
+++ b/interventions/NodePropertyValueChanger.cpp
@@ -16,7 +16,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED( NodePropertyValueChanger )
 
     BEGIN_QUERY_INTERFACE_BODY( NodePropertyValueChanger )
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE( IBaseIntervention )
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_ISUPPORTS_VIA( INodeDistributableIntervention )

--- a/interventions/Outbreak.cpp
+++ b/interventions/Outbreak.cpp
@@ -19,7 +19,6 @@ SETUP_LOGGING( "Outbreak" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(Outbreak)
-        HANDLE_INTERFACE(IConfigurable)
         //HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(INodeDistributableIntervention)

--- a/interventions/OutbreakIndividual.cpp
+++ b/interventions/OutbreakIndividual.cpp
@@ -18,7 +18,6 @@ SETUP_LOGGING( "OutbreakIndividual" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(OutbreakIndividual)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(IOutbreakIndividual)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/PMTCT.cpp
+++ b/interventions/PMTCT.cpp
@@ -10,7 +10,6 @@ SETUP_LOGGING( "PMTCT" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(PMTCT)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(PMTCT)

--- a/interventions/PropertyValueChanger.cpp
+++ b/interventions/PropertyValueChanger.cpp
@@ -18,7 +18,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED(PropertyValueChanger)
 
     BEGIN_QUERY_INTERFACE_BODY(PropertyValueChanger)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/RTSSVaccine.cpp
+++ b/interventions/RTSSVaccine.cpp
@@ -11,7 +11,6 @@ SETUP_LOGGING( "RTSSVaccine" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(RTSSVaccine)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(RTSSVaccine)

--- a/interventions/STIBarrier.cpp
+++ b/interventions/STIBarrier.cpp
@@ -21,7 +21,6 @@ SETUP_LOGGING( "STIBarrier" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(STIBarrier)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)
     END_QUERY_INTERFACE_BODY(STIBarrier)

--- a/interventions/SetSexualDebutAge.cpp
+++ b/interventions/SetSexualDebutAge.cpp
@@ -13,7 +13,6 @@ SETUP_LOGGING( "SetSexualDebugAge" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY( SetSexualDebutAge )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IDistributableIntervention )
         HANDLE_ISUPPORTS_VIA( IDistributableIntervention )
     END_QUERY_INTERFACE_BODY( SetSexualDebutAge )

--- a/interventions/SimpleVaccine.cpp
+++ b/interventions/SimpleVaccine.cpp
@@ -12,7 +12,6 @@ SETUP_LOGGING( "SimpleVaccine" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleVaccine)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
         HANDLE_INTERFACE(IVaccine)

--- a/interventions/StartNewRelationship.cpp
+++ b/interventions/StartNewRelationship.cpp
@@ -16,7 +16,6 @@ SETUP_LOGGING( "StartNewRelationship" )
 namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(StartNewRelationship)
-        HANDLE_INTERFACE(IConfigurable)
         HANDLE_INTERFACE(IDistributableIntervention)
         HANDLE_INTERFACE(INonPfaRelationshipStarter)
         HANDLE_ISUPPORTS_VIA(IDistributableIntervention)

--- a/interventions/VectorControlNodeTargeted.cpp
+++ b/interventions/VectorControlNodeTargeted.cpp
@@ -17,7 +17,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_BODY(SimpleVectorControlNode)
         HANDLE_INTERFACE( IReportInterventionDataAccess )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE(INodeDistributableIntervention)
         HANDLE_INTERFACE(IBaseIntervention)
         HANDLE_ISUPPORTS_VIA(INodeDistributableIntervention)

--- a/interventions/WaningEffect.h
+++ b/interventions/WaningEffect.h
@@ -26,6 +26,8 @@ namespace Kernel
         WaningEffectConstant( const WaningEffectConstant& rOrig );
         virtual ~WaningEffectConstant() {};
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
         virtual IWaningEffect* Clone() override;
         virtual void  Update(float dt) override;
         virtual void  SetCurrentTime(float dt) override {};
@@ -54,6 +56,8 @@ namespace Kernel
         WaningEffectExponential( const WaningEffectExponential& rOrig );
         virtual ~WaningEffectExponential() {};
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
         virtual bool Configure( const Configuration *config ) override;
         virtual IWaningEffect* Clone() override;
         virtual void  Update(float dt) override;
@@ -76,6 +80,8 @@ namespace Kernel
         WaningEffectBox( const WaningEffectBox& rOrig );
         virtual ~WaningEffectBox() {};
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
         virtual bool Configure( const Configuration *config ) override;
         virtual IWaningEffect* Clone() override;
         virtual void  Update(float dt) override;
@@ -97,6 +103,8 @@ namespace Kernel
         WaningEffectBoxExponential();
         WaningEffectBoxExponential( const WaningEffectBoxExponential& rOrig );
         virtual ~WaningEffectBoxExponential() {};
+
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
 
         virtual bool Configure( const Configuration *config ) override;
         virtual IWaningEffect* Clone() override;

--- a/interventions/WaningEffectBox.cpp
+++ b/interventions/WaningEffectBox.cpp
@@ -3,7 +3,6 @@
 
 #include "WaningEffect.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 
 SETUP_LOGGING( "WaningEffectBox" )
 
@@ -11,7 +10,8 @@ namespace Kernel
 {
     // --------------------------- WaningEffectBox ---------------------------
     IMPLEMENT_FACTORY_REGISTERED(WaningEffectBox)
-    IMPL_QUERY_INTERFACE2(WaningEffectBox, IWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectBox)
+    END_QUERY_INTERFACE_BODY(WaningEffectBox)
 
     WaningEffectBox::WaningEffectBox()
     : WaningEffectConstant()

--- a/interventions/WaningEffectBoxExponential.cpp
+++ b/interventions/WaningEffectBoxExponential.cpp
@@ -3,7 +3,6 @@
 
 #include "WaningEffect.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 
 SETUP_LOGGING( "WaningEffectBoxExponential" )
 
@@ -11,7 +10,8 @@ namespace Kernel
 {
     // --------------------------- WaningEffectBoxExponential ---------------------------
     IMPLEMENT_FACTORY_REGISTERED(WaningEffectBoxExponential)
-    IMPL_QUERY_INTERFACE2(WaningEffectBoxExponential, IWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectBoxExponential)
+    END_QUERY_INTERFACE_BODY(WaningEffectBoxExponential)
 
     WaningEffectBoxExponential::WaningEffectBoxExponential()
     : WaningEffectConstant()

--- a/interventions/WaningEffectCombo.cpp
+++ b/interventions/WaningEffectCombo.cpp
@@ -96,7 +96,6 @@ namespace Kernel
     IMPLEMENT_FACTORY_REGISTERED( WaningEffectCombo )
 
     BEGIN_QUERY_INTERFACE_BODY( WaningEffectCombo )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IWaningEffect )
         HANDLE_INTERFACE( IWaningEffectCount )
         HANDLE_ISUPPORTS_VIA( IWaningEffect )

--- a/interventions/WaningEffectCombo.h
+++ b/interventions/WaningEffectCombo.h
@@ -48,6 +48,8 @@ namespace Kernel
         WaningEffectCombo();
         virtual ~WaningEffectCombo();
 
+        virtual IConfigurable*  GetConfigurable()  override  { return JsonConfigurable::GetConfigurable(); }
+
         virtual bool Configure( const Configuration *config ) override;
 
         // IWaningEffect methods

--- a/interventions/WaningEffectConstant.cpp
+++ b/interventions/WaningEffectConstant.cpp
@@ -3,14 +3,14 @@
 
 #include "WaningEffect.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 
 SETUP_LOGGING( "WaningEffectConstant" )
 
 namespace Kernel
 {
     IMPLEMENT_FACTORY_REGISTERED(WaningEffectConstant)
-    IMPL_QUERY_INTERFACE2(WaningEffectConstant, IWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectConstant)
+    END_QUERY_INTERFACE_BODY(WaningEffectConstant)
 
     WaningEffectConstant::WaningEffectConstant()
     : IWaningEffect()

--- a/interventions/WaningEffectExponential.cpp
+++ b/interventions/WaningEffectExponential.cpp
@@ -3,7 +3,6 @@
 
 #include "WaningEffect.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 #include "IArchive.h"
 
 SETUP_LOGGING( "WaningEffectExponential" )
@@ -12,7 +11,8 @@ namespace Kernel
 {
     // --------------------------- WaningEffectExponential ---------------------------
     IMPLEMENT_FACTORY_REGISTERED(WaningEffectExponential)
-    IMPL_QUERY_INTERFACE2(WaningEffectExponential, IWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectExponential)
+    END_QUERY_INTERFACE_BODY(WaningEffectExponential)
 
     WaningEffectExponential::WaningEffectExponential()
     : WaningEffectConstant()

--- a/interventions/WaningEffectMap.cpp
+++ b/interventions/WaningEffectMap.cpp
@@ -3,7 +3,6 @@
 
 #include "WaningEffectMap.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 #include "IArchive.h"
 
 SETUP_LOGGING( "WaningEffectMapAbstract" )
@@ -13,7 +12,9 @@ namespace Kernel
     // ------------------------------------------------------------------------
     // --- WaningEffectMapLinear
     // ------------------------------------------------------------------------
-    IMPL_QUERY_INTERFACE2(WaningEffectMapAbstract, IWaningEffect, IConfigurable)
+
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectMapAbstract)
+    END_QUERY_INTERFACE_BODY(WaningEffectMapAbstract)
 
     WaningEffectMapAbstract::WaningEffectMapAbstract( float maxTime )
     : WaningEffectConstant()

--- a/interventions/WaningEffectRandomBox.cpp
+++ b/interventions/WaningEffectRandomBox.cpp
@@ -3,7 +3,6 @@
 
 #include "WaningEffectRandomBox.h"
 #include "CajunIncludes.h"
-#include "ConfigurationImpl.h"
 #include "IArchive.h"
 #include "IIndividualHumanContext.h"
 #include "RANDOM.h"
@@ -16,7 +15,8 @@ namespace Kernel
     // --- WaningEffectRandomBox
     // ------------------------------------------------------------------------
     IMPLEMENT_FACTORY_REGISTERED(WaningEffectRandomBox)
-    IMPL_QUERY_INTERFACE2(WaningEffectRandomBox, IWaningEffect, IConfigurable)
+    BEGIN_QUERY_INTERFACE_BODY(WaningEffectRandomBox)
+    END_QUERY_INTERFACE_BODY(WaningEffectRandomBox)
 
     WaningEffectRandomBox::WaningEffectRandomBox()
     : WaningEffectConstant()

--- a/reporters/MalariaImmunityReport.cpp
+++ b/reporters/MalariaImmunityReport.cpp
@@ -160,7 +160,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 // ----------------------------------------
 
     BEGIN_QUERY_INTERFACE_BODY( MalariaImmunityReport )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IReport )
         HANDLE_ISUPPORTS_VIA( IReport )
     END_QUERY_INTERFACE_BODY( MalariaImmunityReport )

--- a/reporters/MalariaPatientJSONReport.cpp
+++ b/reporters/MalariaPatientJSONReport.cpp
@@ -188,7 +188,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 // ----------------------------------------
     BEGIN_QUERY_INTERFACE_BODY( MalariaPatientJSONReport )
         HANDLE_INTERFACE( IReportMalariaDiagnostics )
-        HANDLE_INTERFACE( IConfigurable )
     HANDLE_INTERFACE( IReport )
     HANDLE_ISUPPORTS_VIA( IReport )
     END_QUERY_INTERFACE_BODY( MalariaPatientJSONReport )

--- a/reporters/MalariaSummaryReport.cpp
+++ b/reporters/MalariaSummaryReport.cpp
@@ -374,7 +374,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_BODY( MalariaSummaryReport )
         HANDLE_INTERFACE( IReportMalariaDiagnostics )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IReport )
         HANDLE_ISUPPORTS_VIA( IReport )
     END_QUERY_INTERFACE_BODY( MalariaSummaryReport )

--- a/reporters/MalariaSurveyJSONAnalyzer.cpp
+++ b/reporters/MalariaSurveyJSONAnalyzer.cpp
@@ -304,7 +304,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_BODY( MalariaSurveyJSONAnalyzer )
         HANDLE_INTERFACE( IReportMalariaDiagnostics )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IReport )
         HANDLE_ISUPPORTS_VIA( IReport )
     END_QUERY_INTERFACE_BODY( MalariaSurveyJSONAnalyzer )

--- a/reporters/ReportAntibodies.cpp
+++ b/reporters/ReportAntibodies.cpp
@@ -20,7 +20,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportAntibodies, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportAntibodies, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportAntibodies )

--- a/reporters/ReportDrugStatus.cpp
+++ b/reporters/ReportDrugStatus.cpp
@@ -20,7 +20,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportDrugStatus, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportDrugStatus, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportDrugStatus )

--- a/reporters/ReportEventCounter.cpp
+++ b/reporters/ReportEventCounter.cpp
@@ -60,7 +60,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportEventCounter, BaseEventReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportEventCounter, BaseEventReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportFpgNewInfections.cpp
+++ b/reporters/ReportFpgNewInfections.cpp
@@ -32,7 +32,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportFpgNewInfections, BaseTextReportEvents )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportFpgNewInfections, BaseTextReportEvents )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportFpgNewInfections )

--- a/reporters/ReportFpgOutputForObservationalModel.cpp
+++ b/reporters/ReportFpgOutputForObservationalModel.cpp
@@ -26,7 +26,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportFpgOutputForObservationalModel, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportFpgOutputForObservationalModel, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportFpgOutputForObservationalModel )

--- a/reporters/ReportHumanMigrationTracking.cpp
+++ b/reporters/ReportHumanMigrationTracking.cpp
@@ -70,7 +70,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportHumanMigrationTracking, BaseTextReportEvents )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportHumanMigrationTracking, BaseTextReportEvents )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportInfectionDuration.cpp
+++ b/reporters/ReportInfectionDuration.cpp
@@ -18,7 +18,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportInfectionDuration, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportInfectionDuration, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportInfectionDuration )

--- a/reporters/ReportInfectionStatsMalaria.cpp
+++ b/reporters/ReportInfectionStatsMalaria.cpp
@@ -19,7 +19,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportInfectionStatsMalaria, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportInfectionStatsMalaria, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportInfectionStatsMalaria )

--- a/reporters/ReportInterventionPopAvg.cpp
+++ b/reporters/ReportInterventionPopAvg.cpp
@@ -21,7 +21,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportInterventionPopAvg, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportInterventionPopAvg, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportInterventionPopAvg )

--- a/reporters/ReportMalariaFiltered.cpp
+++ b/reporters/ReportMalariaFiltered.cpp
@@ -83,7 +83,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportMalariaFiltered, ReportMalaria )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportMalariaFiltered, ReportMalaria )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportMalariaFilteredIntraHost.cpp
+++ b/reporters/ReportMalariaFilteredIntraHost.cpp
@@ -15,7 +15,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportMalariaFilteredIntraHost, ReportMalariaFiltered )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportMalariaFilteredIntraHost, ReportMalariaFiltered )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportMalariaFilteredIntraHost )

--- a/reporters/ReportMicrosporidia.cpp
+++ b/reporters/ReportMicrosporidia.cpp
@@ -28,7 +28,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportMicrosporidia, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportMicrosporidia, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportMicrosporidia )

--- a/reporters/ReportNodeDemographics.cpp
+++ b/reporters/ReportNodeDemographics.cpp
@@ -19,7 +19,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_DERIVED( ReportNodeDemographics, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportNodeDemographics, BaseTextReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportNodeDemographicsMalaria.cpp
+++ b/reporters/ReportNodeDemographicsMalaria.cpp
@@ -72,7 +72,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
     BEGIN_QUERY_INTERFACE_DERIVED( ReportNodeDemographicsMalaria, ReportNodeDemographics )
         HANDLE_INTERFACE( IReportMalariaDiagnostics )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportNodeDemographicsMalaria, ReportNodeDemographics )
 #ifndef _REPORT_DLL
     IMPLEMENT_FACTORY_REGISTERED( ReportNodeDemographicsMalaria )

--- a/reporters/ReportPfaQueues.cpp
+++ b/reporters/ReportPfaQueues.cpp
@@ -33,7 +33,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportPfaQueues, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportPfaQueues, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportPfaQueues )

--- a/reporters/ReportPluginAgeAtInfection.cpp
+++ b/reporters/ReportPluginAgeAtInfection.cpp
@@ -99,7 +99,6 @@ namespace Kernel
 
 BEGIN_QUERY_INTERFACE_DERIVED( ReportPluginAgeAtInfection, BaseChannelReport )
     HANDLE_INTERFACE( IReport )
-    HANDLE_INTERFACE( IConfigurable )
 END_QUERY_INTERFACE_DERIVED( ReportPluginAgeAtInfection, BaseChannelReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportPluginAgeAtInfectionHistogram.cpp
+++ b/reporters/ReportPluginAgeAtInfectionHistogram.cpp
@@ -101,7 +101,6 @@ namespace Kernel
 
 BEGIN_QUERY_INTERFACE_DERIVED( ReportPluginAgeAtInfectionHistogram, BaseChannelReport )
     HANDLE_INTERFACE( IReport )
-    HANDLE_INTERFACE( IConfigurable )
 END_QUERY_INTERFACE_DERIVED( ReportPluginAgeAtInfectionHistogram, BaseChannelReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportRelationshipCensus.cpp
+++ b/reporters/ReportRelationshipCensus.cpp
@@ -106,7 +106,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportRelationshipCensus, BaseTextReportEvents )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportRelationshipCensus, BaseTextReportEvents )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportRelationshipMigrationTracking.cpp
+++ b/reporters/ReportRelationshipMigrationTracking.cpp
@@ -91,7 +91,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportRelationshipMigrationTracking, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportRelationshipMigrationTracking, BaseTextReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportSimpleMalariaTransmission.cpp
+++ b/reporters/ReportSimpleMalariaTransmission.cpp
@@ -32,7 +32,6 @@ namespace Kernel
     BEGIN_QUERY_INTERFACE_DERIVED( ReportSimpleMalariaTransmission, BaseTextReportEvents )
         HANDLE_INTERFACE( IReportMalariaDiagnostics )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportSimpleMalariaTransmission, BaseTextReportEvents )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportSimpleMalariaTransmission )

--- a/reporters/ReportSimulationStats.cpp
+++ b/reporters/ReportSimulationStats.cpp
@@ -20,7 +20,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_DERIVED( ReportSimulationStats, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportSimulationStats, BaseTextReport )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportSimulationStats )

--- a/reporters/ReportVectorGenetics.cpp
+++ b/reporters/ReportVectorGenetics.cpp
@@ -170,7 +170,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportVectorGenetics, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportVectorGenetics, BaseTextReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportVectorGeneticsMalariaGenetics.cpp
+++ b/reporters/ReportVectorGeneticsMalariaGenetics.cpp
@@ -29,7 +29,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportVectorGeneticsMalariaGenetics, ReportVectorGenetics )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportVectorGeneticsMalariaGenetics, ReportVectorGenetics )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportVectorGeneticsMalariaGenetics )

--- a/reporters/ReportVectorMigration.cpp
+++ b/reporters/ReportVectorMigration.cpp
@@ -77,7 +77,6 @@ GetReportInstantiator( Kernel::instantiator_function_t* pif )
     BEGIN_QUERY_INTERFACE_DERIVED( ReportVectorMigration, BaseTextReport )
         HANDLE_INTERFACE( IVectorMigrationReporting )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportVectorMigration, BaseTextReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportVectorStats.cpp
+++ b/reporters/ReportVectorStats.cpp
@@ -457,7 +457,6 @@ namespace Kernel
 
     BEGIN_QUERY_INTERFACE_DERIVED( ReportVectorStats, BaseTextReportEvents )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportVectorStats, BaseTextReportEvents )
 
 #ifndef _REPORT_DLL

--- a/reporters/ReportVectorStatsMalariaGenetics.cpp
+++ b/reporters/ReportVectorStatsMalariaGenetics.cpp
@@ -18,7 +18,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_DERIVED( ReportVectorStatsMalariaGenetics, ReportVectorStats )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( ReportVectorStatsMalariaGenetics, ReportVectorStats )
 
     IMPLEMENT_FACTORY_REGISTERED( ReportVectorStatsMalariaGenetics )

--- a/reporters/SqlReport.cpp
+++ b/reporters/SqlReport.cpp
@@ -181,7 +181,6 @@ namespace Kernel
     // ----------------------------------------
 
     BEGIN_QUERY_INTERFACE_BODY( SqlReport )
-        HANDLE_INTERFACE( IConfigurable )
         HANDLE_INTERFACE( IReport )
         HANDLE_ISUPPORTS_VIA( IReport )
     END_QUERY_INTERFACE_BODY( SqlReport )

--- a/reporters/VectorHabitatReport.cpp
+++ b/reporters/VectorHabitatReport.cpp
@@ -75,7 +75,6 @@ namespace Kernel
 
 BEGIN_QUERY_INTERFACE_DERIVED( VectorHabitatReport, BinnedReport )
     HANDLE_INTERFACE( IReport )
-    HANDLE_INTERFACE( IConfigurable )
 END_QUERY_INTERFACE_DERIVED( VectorHabitatReport, BinnedReport )
 
 #ifndef _REPORT_DLL

--- a/reporters/libstirelationshipqueuereporter/StiRelationshipQueueReporter.cpp
+++ b/reporters/libstirelationshipqueuereporter/StiRelationshipQueueReporter.cpp
@@ -81,7 +81,6 @@ namespace Kernel
 {
     BEGIN_QUERY_INTERFACE_DERIVED( StiRelationshipQueueReporter, BaseTextReport )
         HANDLE_INTERFACE( IReport )
-        HANDLE_INTERFACE( IConfigurable )
     END_QUERY_INTERFACE_DERIVED( StiRelationshipQueueReporter, BaseTextReport )
 
     StiRelationshipQueueReporter::StiRelationshipQueueReporter()

--- a/utils/ConfigurationImpl.h
+++ b/utils/ConfigurationImpl.h
@@ -10,53 +10,6 @@
 
 namespace Kernel
 {
-    namespace MetadataDescriptor 
-    {
-        struct Enum; // forward decl
-    }
-
-    struct ConfigurationImpl // overloaded functions wrapping config retrieval
-    {
-        static void get_config_value(const Configuration* config, std::string name, float *value)
-        {
-            *value = GET_CONFIG_NUMBER(config, name);
-        }
-
-        static void get_config_value(const Configuration* config, std::string name, std::string *value)
-        {
-            *value = GET_CONFIG_STRING(config, name);
-        }
-
-        static void get_config_value(const Configuration* config, std::string name, bool *value)
-        {
-            bool  v = GET_CONFIG_DOUBLE(config, name) != 0; // redundant conversion to get rid of inexplicable warning C4800 on msvc. 
-            (*value) = v;
-        }
-
-        static void get_config_value(const Configuration* config, std::string name, int *value)
-        {
-            *value = GET_CONFIG_INTEGER(config, name);
-        }
-
-        static void get_config_value(const Configuration* config, std::string name, IConfigurable *value)
-        {
-            // TODO: error handling here?...could also pass back return codes
-            // need to catch json lookup exceptions here and report errors
-            value->Configure((const Configuration*)&((*config)[name]));
-        }
-
-        static void get_config_value(const Configuration* config, std::string name, Configuration ** pp_cached_config)
-        {
-            // TODO: error handling here?...could also pass back return codes
-            // need to catch json lookup exceptions here and report errors
-
-            *pp_cached_config = Configuration::CopyFromElement( (*config)[name], config->GetDataLocation() );
-        }
-    };
-
-    class ModeConfigure { };
-    class ModeGetSchema { };
-
     namespace MetadataDescriptor
     {
         struct Base
@@ -114,145 +67,21 @@ namespace Kernel
                 Enum(_name, _desc, count, strings, values)
             {
             }
-            // for a list of enums, the default is emtpy list 
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["type"] = json::String(GetTypeString());
-
-                for (int k = 0; k < enum_value_specs.size(); k++)
-                {
-                    qb["enum"][k] = json::String(enum_value_specs[k].first);
-                }
-
-                qb["description"] = json::String(description);
-                qb["default"] = json::Array();
-                return member;
-            }
 
             virtual const char *GetTypeString()
             {
                 return "Vector Enum";
             }
-        };
-
-        struct Bool : public Base
-        {
-            Bool(std::string _name, std::string _desc) : Base(_name, _desc) {}
 
             virtual Element GetSchemaElement()
             {
-                Element member = Object();
+                Element member = Enum::GetSchemaElement();
                 QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("bool");
-                qb["description"] = json::String(description);
 
-                return member;
-            }
-        };
-
-        struct String : public Base
-        {
-            String(std::string _name, std::string _desc) : Base(_name, _desc) {}
-
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("string");
-                qb["description"] = json::String(description);
-
-                return member;
-            }
-        };
-
-        struct Integer : public Base
-        {
-            Integer(std::string _name, std::string _desc) : Base(_name, _desc), has_min(false), has_max(false) {}
-            Integer(std::string _name, std::string _desc, int _min, int _max) : Base(_name, _desc), m_min(_min), m_max(_max), has_min(true), has_max(true) {}
-
-            bool has_min, has_max;
-            int m_min, m_max;
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("int");
-                if (has_min)
-                    qb["min"] = Number(m_min);
-                if (has_max)
-                    qb["max"] = Number(m_max);
-
-                qb["description"] = json::String(description);
-
-                return member;
-            }
-        };
-
-        struct Real : public Base
-        {
-            Real(std::string _name, std::string _desc) : Base(_name, _desc), has_min(false), has_max(false) {}
-            Real(std::string _name, std::string _desc, float _min, float _max) : Base(_name, _desc), m_min(_min), m_max(_max), has_min(true), has_max(true) {}
-
-            bool has_min, has_max;
-            float m_min, m_max;
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("real");
-                if (has_min) 
-                    qb["min"] = Number(m_min);
-                if (has_max)
-                    qb["max"] = Number(m_max);
-
-                qb["description"] = json::String(description);
-
-                return member;
-            }
-        };
-
-        struct Configuration : public Base
-        {
-            Configuration(std::string _name, std::string _desc) : Base(_name, _desc) {}
-
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("configuration");
-                qb["description"] = json::String(description);
-
-                return member;
-            }
-        };
-
-        struct Configurable : public Base
-        {
-            Configurable(std::string _name, std::string _desc, IConfigurable* _object) : Base(_name, _desc), object(_object) {}
-
-            IConfigurable *object;
-            virtual Element GetSchemaElement()
-            {
-                Element member = Object();
-                QuickBuilder qb(member);
-                qb["name"] = json::String(name);
-                qb["type"] = json::String("object");
-                qb["description"] = json::String(description);
-#ifdef _WIN32
-                qb["schema"] = object->GetSchema();
-#else
-#warning "line of code for GetSchema commented out to get to build on linux"
-#endif
+                // for a list of enums, the default is emtpy list
+                qb["default"] = json::Array();
                 return member;
             }
         };
     }
-
 }

--- a/utils/Configure.cpp
+++ b/utils/Configure.cpp
@@ -994,6 +994,7 @@ namespace Kernel
                 updateSchemaWithCondition(newParamSchema, (pair.first).c_str(), (pair.second).c_str());
             }
         }
+
         jsonSchemaBase[paramName] = newParamSchema;
     }
 

--- a/utils/FactorySupport.h
+++ b/utils/FactorySupport.h
@@ -30,7 +30,7 @@ namespace Kernel
     typedef map<string, instantiator_function_t> support_spec_map_t;
 
     template <class ReturnTypeT>
-    ReturnTypeT* CreateInstanceFromSpecs(const Configuration* config, support_spec_map_t &specs, bool query_for_return_interface = true)
+    ReturnTypeT* CreateInstanceFromSpecs(const Configuration* config, support_spec_map_t &specs)
     {
         string classname = "PREPARSED_CLASSNAME";
         try {
@@ -64,25 +64,6 @@ namespace Kernel
             obj = it->second(); // create object
             obj->AddRef(); // increment reference counting for 'obj'
 
-            /* now return an interface type the user actually wants*/
-            if( query_for_return_interface )
-            {
-                ReturnTypeT *ri = nullptr;
-
-                // get iid. Interesting issue here where macros and templates args interact unpredictably.
-                string templateClassName = typeid( ReturnTypeT ).name();
-                templateClassName = templateClassName.substr( templateClassName.find_last_of( "::" ) + 1 );
-
-                if( s_OK != obj->QueryInterface( TypeInfo<ReturnTypeT>::GetIID( (char*)templateClassName.c_str() ), (void**)&ri ) )
-                {
-                    /* Didn't even support what we wanted, dispose of it and return null */
-                    obj->Release();
-                    return nullptr;
-                }
-
-                obj->Release(); // reduce reference count as 'obj' is going out of scope
-            }
-    
             IConfigurable* conf_obj = obj->GetConfigurable();
             release_assert(conf_obj);
 

--- a/utils/FactorySupport.h
+++ b/utils/FactorySupport.h
@@ -22,7 +22,6 @@
 namespace Kernel
 {
     using namespace std;
-    using namespace json;
 
     //////////////////////////////////////////////////////////////////////////
     // CreateInstance/ClassFactory helpers
@@ -64,7 +63,7 @@ namespace Kernel
         {
             obj = it->second(); // create object
             obj->AddRef(); // increment reference counting for 'obj'
-            
+
             /* now return an interface type the user actually wants*/
             if( query_for_return_interface )
             {
@@ -84,22 +83,15 @@ namespace Kernel
                 obj->Release(); // reduce reference count as 'obj' is going out of scope
             }
     
-            IConfigurable *conf_obj = nullptr;
-            if (s_OK == obj->QueryInterface(GET_IID(IConfigurable), (void**)&conf_obj))
+            IConfigurable* conf_obj = obj->GetConfigurable();
+            release_assert(conf_obj);
+
+            if (!conf_obj->Configure(config))
             {
-                if (!conf_obj->Configure(config))
-                {
-                    // release references to the objects
-                    conf_obj->Release();
-                    obj->Release();
-                    return nullptr;
-                }
+                // release references to the objects
+                obj->Release();
+                return nullptr;
             }
-            else
-            {
-                // should we throw an exception?
-            }
-            if( conf_obj ) conf_obj->Release();  // release reference as 'conf_obj' is going out of scope.
         }
 
         // returning a plain object pointer type, force casted

--- a/utils/ISupports.h
+++ b/utils/ISupports.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "IdmApi.h"
+#include "Debug.h"
 #include <string>
 #include <list>
 #include <vector>

--- a/utils/ObjectFactory.h
+++ b/utils/ObjectFactory.h
@@ -48,7 +48,7 @@ namespace Kernel
                              bool skip_exceptions=true );
 
     protected:
-        ObjectFactory( bool queryForReturnInterface=true );
+        ObjectFactory();
 
         // Provides a hook for the factory to add other stuff to the schema for an object
         virtual void ModifySchema( json::QuickBuilder& rSchema, ISupports* pObject ){};
@@ -60,7 +60,6 @@ namespace Kernel
 
         support_spec_map_t m_RegisteredClasses;
         json::Object       m_FactorySchema;
-        bool               m_QueryForReturnInterface;
 
         static Factory* _instance;
     };

--- a/utils/ObjectFactory.h
+++ b/utils/ObjectFactory.h
@@ -51,7 +51,7 @@ namespace Kernel
         ObjectFactory( bool queryForReturnInterface=true );
 
         // Provides a hook for the factory to add other stuff to the schema for an object
-        virtual void ModifySchema( json::QuickBuilder& rSchema, ISupports*pObject ){};
+        virtual void ModifySchema( json::QuickBuilder& rSchema, ISupports* pObject ){};
 
         // Returns the name fo the factory
         std::string GetFactoryName();

--- a/utils/ObjectFactoryTemplates.h
+++ b/utils/ObjectFactoryTemplates.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "Configure.h"
 #include "ObjectFactory.h"
 #ifndef WIN32
 #include <cxxabi.h>
@@ -58,11 +59,8 @@ namespace Kernel
             // --------------------------------
             // --- Get the schema for the class
             // --------------------------------
-            IConfigurable* p_config = nullptr;
-            if( s_OK != pForSchema->QueryInterface( GET_IID( IConfigurable ), (void**)&p_config ) )
-            {
-                throw QueryInterfaceException( __FILE__, __LINE__, __FUNCTION__, "ret", "IConfigurable", "ISupports" );
-            }
+            IConfigurable* p_config = pForSchema->GetConfigurable();
+            release_assert( p_config );
 
             Configuration* fakeConfig = Configuration::CopyFromElement( fakeJson );
             p_config->Configure( fakeConfig );
@@ -204,11 +202,8 @@ namespace Kernel
 
         std::string sim_type_str = GET_CONFIG_STRING( EnvPtr->Config, "Simulation_Type" );
 
-        IConfigurable* p_config = nullptr;
-        if( s_OK != pObject->QueryInterface( GET_IID( IConfigurable ), (void**)&p_config ) )
-        {
-            throw QueryInterfaceException( __FILE__, __LINE__, __FUNCTION__, "pObject", "IConfigurable", "IObject" );
-        }
+        IConfigurable* p_config = pObject->GetConfigurable();
+        release_assert(p_config);
 
 
         json::Array sim_type_array = p_config->GetSimTypes();

--- a/utils/ObjectFactoryTemplates.h
+++ b/utils/ObjectFactoryTemplates.h
@@ -16,10 +16,9 @@ namespace Kernel
     }
 
     template<class IObject, class Factory>
-    ObjectFactory<IObject,Factory>::ObjectFactory( bool queryForReturnInterface )
+    ObjectFactory<IObject,Factory>::ObjectFactory()
         : m_RegisteredClasses()
         , m_FactorySchema()
-        , m_QueryForReturnInterface( queryForReturnInterface )
     {
     }
 
@@ -89,7 +88,7 @@ namespace Kernel
         ElementIsValid( rJsonElement, rDataLocation, parameterName, false );
 
         Configuration* pConfig = Configuration::CopyFromElement( rJsonElement, rDataLocation );
-        IObject* obj = CreateInstanceFromSpecs<IObject>( pConfig, m_RegisteredClasses, m_QueryForReturnInterface );
+        IObject* obj = CreateInstanceFromSpecs<IObject>( pConfig, m_RegisteredClasses );
 
         if( !obj )
         {


### PR DESCRIPTION
Removes 1 of 82 instances of the QueryInterface pattern (this PR targets IConfigurable).

Largely unplanned contribution because I was curious how long it would take with the support of Claude. Removing QI in EMOD-Generic manually was kind of unpleasant.
